### PR TITLE
Add UserCampaign Object Association Model

### DIFF
--- a/models.py
+++ b/models.py
@@ -30,7 +30,7 @@ class User(UserMixin, db.Model):
     comments = db.relationship("Comment", back_populates="author")
 
 
-class Campaign(UserMixin, db.Model):
+class Campaign(db.Model):
     __tablename__ = "campaign"
 
     id = db.Column(db.Integer, primary_key=True)
@@ -46,7 +46,7 @@ class Campaign(UserMixin, db.Model):
     members = db.relationship("User", secondary=user_campaign, back_populates="campaigns")
 
 
-class Event(UserMixin, db.Model):
+class Event(db.Model):
     __tablename__ = "event"
 
     id = db.Column(db.Integer, primary_key=True)
@@ -68,7 +68,7 @@ class Event(UserMixin, db.Model):
     parent_campaign = db.relationship("Campaign", back_populates="events")
 
 
-class Comment(UserMixin, db.Model):
+class Comment(db.Model):
     __tablename__ = "comment"
 
     id = db.Column(db.Integer, primary_key=True)

--- a/models.py
+++ b/models.py
@@ -2,15 +2,26 @@ from flask_login import UserMixin
 
 from app import db
 
-# Association table that defines user to campaign relationships
-user_campaign = db.Table("user_campaign",
-                         db.Column("user_id", db.Integer, db.ForeignKey("user.id")),
-                         db.Column("campaign_id", db.Integer, db.ForeignKey("campaign.id")))
-
 # Association table that defines user to campaign editing permissions.
 user_edit_permissions = db.Table("user_edit_permissions",
                                  db.Column("user_id", db.Integer, db.ForeignKey("user.id")),
                                  db.Column("campaign_id", db.Integer, db.ForeignKey("campaign.id")))
+
+
+# Association Object that defines user to campaign membership, and allows
+# users to have a unique callsign for each campaign.
+class UserCampaign(db.Model):
+    __tablename__ = 'user_campaign'
+
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), primary_key=True)
+    campaign_id = db.Column(db.Integer, db.ForeignKey('campaign.id'), primary_key=True)
+    callsign = db.Column(db.String(50))
+
+    # Association between UserCampaign -> User
+    user = db.relationship('User', back_populates="campaign_associations")
+
+    # Association between UserCampaign -> Campaign
+    campaign = db.relationship('Campaign', back_populates="user_associations")
 
 
 class User(UserMixin, db.Model):
@@ -24,7 +35,14 @@ class User(UserMixin, db.Model):
     # Database relationships
     # A user takes part in a number of campaigns, may have editing permissions, and may be the author of many comments.
 
-    campaigns = db.relationship("Campaign", secondary=user_campaign, back_populates="members")
+    # Many-to-many relationship to Campaign, bypassing the `UserCampaign` class
+    campaigns = db.relationship("Campaign",
+                                secondary="user_campaign",
+                                back_populates="members")
+
+    # Association between User -> UserCampaign -> Campaign
+    campaign_associations = db.relationship("UserCampaign", back_populates="user", cascade="delete, delete-orphan")
+
     permissions = db.relationship("Campaign", secondary=user_edit_permissions)
 
     comments = db.relationship("Comment", back_populates="author")
@@ -43,7 +61,14 @@ class Campaign(db.Model):
     # permission.
 
     events = db.relationship("Event", back_populates="parent_campaign")
-    members = db.relationship("User", secondary=user_campaign, back_populates="campaigns")
+
+    # Many-to-many relationship to User, bypassing the `UserCampaign` class
+    members = db.relationship("User",
+                              secondary="user_campaign",
+                              back_populates="campaigns")
+
+    # Association between Child -> Association -> Parent
+    user_associations = db.relationship("UserCampaign", back_populates="campaign", cascade="delete, delete-orphan")
 
 
 class Event(db.Model):

--- a/routes.py
+++ b/routes.py
@@ -219,7 +219,7 @@ def configure_routes(flask_app):
 
             # Add new campaign to database
             db.session.add(new_campaign)
-            # Add current user as campaign member
+            # Add current user as campaign member, callsign will be set to None
             user.campaigns.append(new_campaign)
             # Give current user campaign editing permissions
             user.permissions.append(new_campaign)


### PR DESCRIPTION
Replaces the user_campaign association table with a UserCampaign object. 
This allows for the storing of a "callsign" string, unique to each association. In practice, users can now set a 'callsign' that is unique for each campaign they take part in.