### PR TITLE
Timeline Data Refactor

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -56,10 +56,10 @@ class CreateEventForm(FlaskForm):
     title = StringField("Event Title", validators=[DataRequired()])
     type = StringField("Event Type", validators=[DataRequired()])
     date = StringField("Event Date", validators=[InputRequired(), date_format()])
-    location = StringField("Location", validators=[DataRequired()])
-    belligerents = StringField("Belligerents", validators=[DataRequired()])
+    location = StringField("Location", validators=[Optional()])
+    belligerents = StringField("Belligerents", validators=[Optional()])
     body = TextAreaField("Description", validators=[DataRequired()])
-    result = StringField("Result", validators=[DataRequired()])
+    result = StringField("Result", validators=[Optional()])
     header = BooleanField("Header", default=False, validators=[Optional()])
     submit = SubmitField("Create Event")
 

--- a/routes/campaign/routes.py
+++ b/routes/campaign/routes.py
@@ -36,9 +36,8 @@ def show_timeline(campaign_name, campaign_id):
     campaign = db.session.execute(select(models.Campaign).filter_by(id=campaign_id, title=campaign_name)).scalar()
 
     grouped_events = organisers.campaign_sort(campaign)
-    year_markers = organisers.get_year_markers(grouped_events)
 
-    return render_template("timeline.html", campaign=campaign, timeline_data=grouped_events, year_markers=year_markers)
+    return render_template("timeline.html", campaign=campaign, timeline_data=grouped_events)
 
 
 # View campaign editing page
@@ -52,9 +51,8 @@ def edit_timeline(campaign_name, campaign_id):
 
     # Sort event data for template rendering
     grouped_events = organisers.campaign_sort(campaign)
-    year_markers = organisers.get_year_markers(grouped_events)
 
-    return render_template("edit_timeline.html", campaign=campaign, timeline_data=grouped_events, year_markers=year_markers)
+    return render_template("edit_timeline.html", campaign=campaign, timeline_data=grouped_events)
 
 
 # Create new campaign

--- a/templates/base/sidebar.html
+++ b/templates/base/sidebar.html
@@ -4,17 +4,17 @@
 
     <a class="sidebar-button" href="#year-{{year}}">
       <button class="year-button entry-button">
-        {{ year + campaign.date_suffix}}
+        {{ year.name + campaign.date_suffix}}
         </button> 
     </a>
     
         
-      {% for month in timeline_data[year] %}
+      {% for month in year.months %}
 
 
-        {% for day in timeline_data[year][month] %}
+        {% for day in month.days %}
 
-          {% for event in timeline_data[year][month][day]  %}
+          {% for event in day.events  %}
             <a class="sidebar-button" href="#event-{{event.id}}">
               <button class="event-button">
                 {{event.title}}

--- a/templates/edit_timeline.html
+++ b/templates/edit_timeline.html
@@ -97,17 +97,17 @@
             <div class="timeline-year-container">
 
               <h3 class="timeline-year-header" id="year-{{year}}">
-                {{ year + campaign.date_suffix}}
+                {{ year.name + campaign.date_suffix}}
               </h3> 
 
               <div class="timeline-columns">
 
                 <!-- Check if the timeline data is long enough to warrant an extra year marker -->
-                {%if year_markers[loop.index0] %}
+                {%if year.marker %}
                 <div class="timeline-left-marker">
                   <div class="year-marker-hr"></div>
                   <div class="year-marker-line"></div>
-                  <h5 class="year-marker">{{ year + campaign.date_suffix}}</h5>
+                  <h5 class="year-marker">{{ year.name + campaign.date_suffix}}</h5>
                   <div class="year-marker-line"></div>
                   <div class="year-marker-hr"></div>
                 </div>
@@ -115,7 +115,7 @@
                 <div class="timeline-left-marker marker-invis">
                   <div class="year-marker-hr marker-invis"></div>
                   <div class="year-marker-line marker-invis"></div>
-                  <h5 class="year-marker marker-invis">{{ year + campaign.date_suffix}}</h5>
+                  <h5 class="year-marker marker-invis">{{ year.name + campaign.date_suffix}}</h5>
                   <div class="year-marker-line marker-invis"></div>
                   <div class="year-marker-hr marker-invis"></div>
                 </div>
@@ -135,7 +135,7 @@
             <div class="timeline-months-container">
 
               <!-- Month branch of each year -->
-              {% for month in timeline_data[year] %}
+              {% for month in year.months %}
 
                 {% if loop.first %}
                 <div class="month-outer month-outer-top">
@@ -145,11 +145,16 @@
                 <div class="month-outer">
                 {% endif %}
 
+
+                {% if month.header and loop.first %}
+                <div class="month-connector hidden-date">
+                {% else %}
                 <div class="month-connector">
+                {% endif %}
                   <div class="line line-first"></div>
                   <div class="connector-date connector-date-outline">
                     <div class="connector-date">
-                      {{ month }}
+                      {{ month.name }}
                     </div>
                   </div>
                   <div class="line"></div>
@@ -158,7 +163,7 @@
                 <div class="timeline-month">
 
                   <!-- Day sub branches within each month -->
-                  {% for day in timeline_data[year][month] %}
+                  {% for day in month.days %}
 
                     {% if loop.length == 1 %}
                     <div class="timeline-day-container">
@@ -178,7 +183,7 @@
                     {% endif %}
 
                       {# Check if the first event in the month is a header event, and their are no sub events #}
-                      {% if (timeline_data[year][month][day][0].header) and (timeline_data[year][month][day] | length == 1) and (loop.first) %}
+                      {% if day.header and loop.first %}
                       <div class="right-branch-label hidden-date">
                       {% else %}
                       <div class="right-branch-label">
@@ -188,7 +193,7 @@
                           <div class="line line-first"></div>
                           <div class="connector-date connector-date-outline">
                             <div class="connector-date">
-                              {{day}}
+                              {{day.name}}
                             </div>
                           </div>
                           <div class="line line-spacer"></div>
@@ -197,7 +202,7 @@
 
                       <div class="event-group-container">
                         
-                        {% for event in timeline_data[year][month][day]%}
+                        {% for event in day.events %}
 
                           {% if loop.length == 1 %}
                           <div class="timeline-day-container day-container-solo">
@@ -215,7 +220,7 @@
 
                             <div class="right-branch-label">
                               {# Check if the first event in the day is a header event #}
-                              {% if event.header and loop.first %}
+                              {% if day.header and loop.first %}
                               <div class="date-label-area hidden-date">
                               {% else %}
                               <div class="date-label-area">
@@ -233,7 +238,7 @@
                             <div class="timeline-event event-outline">
                               <div id="event-{{event.id}}" class="timeline-event">
                                 {# Check if event is a header event #}
-                                {% if (event.header) and (loop.first) %}
+                                {% if event.header and loop.first %}
                                 <div class="event-header event-header-highlight">
                                   //{{event.title}}
                                 </div>
@@ -269,7 +274,7 @@
                                         campaign_id=campaign.id,
                                         new_hour=True, 
                                         date=event.date) }}">
-                              <button id="new_event-{{year}}-{{month}}" class="new-timeline-item timeline-between-events">
+                              <button id="new_event-{{year.name}}-{{month.name}}" class="new-timeline-item timeline-between-events">
                                 <img class="icon icon-invert" src="/static/images/icons/plus.svg">
                               </button>
                              </a>
@@ -291,8 +296,8 @@
                                 campaign_name=campaign.title, 
                                 campaign_id=campaign.id,
                                 new_day=True, 
-                                date=year + '-' + month + '-' + day + ' 00:00:00') }}">
-                      <button id="new_event-{{year}}-{{month}}" class="new-timeline-item timeline-between-events">
+                                date=year.name + '-' + month.name + '-' + day.name + ' 00:00:00') }}">
+                      <button id="new_event-{{year.name}}-{{month.name}}" class="new-timeline-item timeline-between-events">
                         <img class="icon icon-invert" src="/static/images/icons/plus.svg">
                       </button>
                      </a>
@@ -317,8 +322,8 @@
                                         campaign_name=campaign.title,
                                         new_month=True, 
                                         campaign_id=campaign.id,
-                                        date=year + '-' + month + '-' + '01' + ' 00:00:00') }}">
-                    <button id="new_event-{{year}}-{{month}}" class="new-timeline-item">
+                                        date=year.name + '-' + month.name + '-' + '01' + ' 00:00:00') }}">
+                    <button id="new_event-{{year.name}}-{{month.name}}" class="new-timeline-item">
                       <img class="icon icon-invert" src="/static/images/icons/plus.svg">
                     </button>
                   </a>

--- a/templates/edit_timeline.html
+++ b/templates/edit_timeline.html
@@ -145,8 +145,9 @@
                 <div class="month-outer">
                 {% endif %}
 
-
-                {% if month.header and loop.first %}
+                {# Check if the year has only one month, and that month has the header property #}
+                {% if month.header %}
+                {# If so, hide the month connector element #}
                 <div class="month-connector hidden-date">
                 {% else %}
                 <div class="month-connector">
@@ -183,7 +184,7 @@
                     {% endif %}
 
                       {# Check if the first event in the month is a header event, and their are no sub events #}
-                      {% if day.header and loop.first %}
+                      {% if day.header %}
                       <div class="right-branch-label hidden-date">
                       {% else %}
                       <div class="right-branch-label">
@@ -220,7 +221,7 @@
 
                             <div class="right-branch-label">
                               {# Check if the first event in the day is a header event #}
-                              {% if day.header and loop.first %}
+                              {% if event.header and loop.first %}
                               <div class="date-label-area hidden-date">
                               {% else %}
                               <div class="date-label-area">

--- a/templates/timeline.html
+++ b/templates/timeline.html
@@ -91,17 +91,17 @@
             <div class="timeline-year-container">
 
               <h3 class="timeline-year-header" id="year-{{year}}">
-                {{ year + campaign.date_suffix}}
+                {{ year.name + campaign.date_suffix}}
               </h3> 
 
               <div class="timeline-columns">
 
                 <!-- Check if the timeline data is long enough to warrant an extra year marker -->
-                {%if year_markers[loop.index0] %}
+                {% if year.marker %}
                 <div id="timeline-left-marker" class="timeline-left-marker">
                   <div class="year-marker-hr"></div>
                   <div class="year-marker-line"></div>
-                  <h5 class="year-marker">{{ year + campaign.date_suffix}}</h5>
+                  <h5 class="year-marker">{{ year.name + campaign.date_suffix}}</h5>
                   <div class="year-marker-line"></div>
                   <div class="year-marker-hr"></div>
                 </div>
@@ -109,7 +109,7 @@
                 <div id="timeline-left-marker" class="timeline-left-marker marker-invis">
                   <div class="year-marker-hr marker-invis"></div>
                   <div class="year-marker-line marker-invis"></div>
-                  <h5 class="year-marker marker-invis">{{ year + campaign.date_suffix}}</h5>
+                  <h5 class="year-marker marker-invis">{{ year.name + campaign.date_suffix}}</h5>
                   <div class="year-marker-line marker-invis"></div>
                   <div class="year-marker-hr marker-invis"></div>
                 </div>
@@ -131,7 +131,7 @@
             <div class="timeline-months-container">
 
               <!-- Month branch of each year -->
-              {% for month in timeline_data[year] %}
+              {% for month in year.months %}
 
                 {% if loop.first %}
                 <div class="month-outer month-outer-top">
@@ -141,11 +141,15 @@
                 <div class="month-outer">
                 {% endif %}
 
+                {% if month.header and loop.first %}
+                <div class="month-connector hidden-date">
+                {% else %}
                 <div class="month-connector">
+                {% endif %}
                   <div class="line line-first"></div>
                   <div class="connector-date connector-date-outline">
                     <div class="connector-date">
-                      {{ month }}
+                      {{ month.name }}
                     </div>
                   </div>
                   <div class="line"></div>
@@ -154,8 +158,7 @@
                 <div class="timeline-month">
 
                   <!-- Day sub branches within each month -->
-                  {% for day in timeline_data[year][month] %}
-
+                  {% for day in month.days %}
 
                       {% if loop.length == 1 %}
                       <div class="timeline-day-container">
@@ -175,7 +178,7 @@
                       {% endif %}
 
                       {# Check if the first event in the month is a header event, and their are no sub events #}
-                      {% if (timeline_data[year][month][day][0].header) and (timeline_data[year][month][day] | length == 1) and (loop.first) %}
+                      {% if day.header and loop.first %}
                       <div class="right-branch-label hidden-date">
                       {% else %}
                       <div class="right-branch-label">
@@ -185,7 +188,7 @@
                           <div class="line line-first"></div>
                           <div class="connector-date connector-date-outline">
                             <div class="connector-date">
-                              {{day}}
+                              {{day.name}}
                             </div>
                           </div>
                           <div class="line line-spacer"></div>
@@ -194,7 +197,7 @@
 
                       <div class="event-group-container">
                         
-                        {% for event in timeline_data[year][month][day]%}
+                        {% for event in day.events %}
 
                           {% if loop.length == 1 %}
                           <div class="timeline-day-container day-container-solo">
@@ -230,7 +233,7 @@
                             <div class="timeline-event event-outline">
                               <div id="event-{{event.id}}" class="timeline-event">
                                 {# Check if event is a header event #}
-                                {% if (event.header) and (loop.first) %}
+                                {% if event.header and loop.first %}
                                 <div class="event-header event-header-highlight">
                                   //{{event.title}}
                                 </div>

--- a/templates/timeline.html
+++ b/templates/timeline.html
@@ -141,7 +141,7 @@
                 <div class="month-outer">
                 {% endif %}
 
-                {% if month.header and loop.first %}
+                {% if month.header %}
                 <div class="month-connector hidden-date">
                 {% else %}
                 <div class="month-connector">
@@ -178,7 +178,7 @@
                       {% endif %}
 
                       {# Check if the first event in the month is a header event, and their are no sub events #}
-                      {% if day.header and loop.first %}
+                      {% if day.header %}
                       <div class="right-branch-label hidden-date">
                       {% else %}
                       <div class="right-branch-label">

--- a/utils/organisers.py
+++ b/utils/organisers.py
@@ -96,35 +96,32 @@ def campaign_sort(campaign):
         year_object.name = year
         year_object.marker = check_year_marker(grouped_events[year])
 
-        for month, month_value in grouped_events[year].items():
+        for month in grouped_events[year]:
 
             month_object = Month()
             month_object.name = month
 
-            for day, day_value in grouped_events[year][month].items():
+            for day in grouped_events[year][month]:
 
                 day_object = Day()
                 day_object.name = day
 
                 for event in grouped_events[year][month][day]:
 
-                    # Check if the event is a header event
-                    day_object.header = check_header(event, event_layer=True)
-                    # Finally, append the event to the day object
+                    # Append the event to the day object
                     day_object.events.append(event)
 
-                # Check if the day is header day
-                day_object.header = check_header(day_value, day_layer=True)
-                # Finally, append the day object to the month object
+                # Append the day object to the month object
                 month_object.days.append(day_object)
 
-            # Check if the month is a header month
-            month_object.header = check_header(month_value, month_layer=True)
-            # Finally, append the month object to the year object
+            # Append the month object to the year object
             year_object.months.append(month_object)
 
-        # Finally, append the year object to the formatted list
+        # Append the year object to the formatted list
         year_list.append(year_object)
+
+        # Finally, take the list of year objects and check them for header status
+        check_headers(year_list)
 
     return year_list
 
@@ -153,28 +150,26 @@ def check_year_marker(year):
 
 
 
-def check_header(group_data, month_layer=False, day_layer=False, event_layer=False):
-    """Check if a given group from campaign_sort necessitates a header property."""
-    if month_layer:
-        # If the first event of the first day of the first month has the header property
-        # and each layer beneath has no sub elements
-        for index, day in enumerate(group_data.values()):
-            if index == 0:
-                for day_index, event in enumerate(day):
-                    if day_index == 0 and len(group_data) == 1 and event.header:
-                        return True
+def check_headers(year_list):
+    """Takes the list of year objects and checks each month and day within them,
+    flagging the header properties."""
 
-    if day_layer:
-        # If the first event of the day has the header property
-        # and each layer beneath has no sub elements
-        for index, event in enumerate(group_data):
-            if index == 0 and len(group_data) == 1 and event.header:
-                return True
+    for year_index, year in enumerate(year_list):
 
-    if event_layer:
-        # If the given event has the header property
-        if group_data.header:
-            return True
+        for month_index, month in enumerate(year.months):
+
+            for day_index, day in enumerate(month.days):
+
+                # Give the day the header property, if the month has only one day,
+                # and that day has only one event with the header property.
+                if len(month.days) == 1 and len(day.events) == 1 and day.events[0].header:
+                    day.header = True
+
+            # Give the month the header property, if the year has only one month,
+            # and that month's first day has the header property.
+            if len(year.months) == 1 and month.days[0].header:
+                month.header = True
+
 
 
 def format_event_datestring(datestring, args):


### PR DESCRIPTION
Refactors the campaign event data for easier timeline templating. Rather than a collection of nested dictionaries, now the event data is given as a list of nested objects, each with a month attribute. Each month is a list of days, and each day holds the events of that day.

This allows additional properties to be easily accessed within the jinja template, in this case, months and days are assigned the "header" property, based on if the month or event is the only one in a loop, and if their are child objects that themselves carry the "header" property. This avoids the need for large nested loops within the template itself.