### PR TITLE
Campaigns  Page Layout Toggle

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1596,9 +1596,7 @@ h5 {
   border: 1px solid var(--dark_red);
   border-radius: 3px;
   margin-top: 25px;
-  padding: 1px;
   transition: 0.15s;
-  background-color: var(--darker_red);
 }
 
 .campaign-view-toggle {
@@ -1613,6 +1611,16 @@ h5 {
   transition: 0.15s;
   background-color: var(--elem_dark);
   stroke: var(--darker_red);
+}
+
+.view-toggle-left {
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+}
+
+.view-toggle-right {
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
 }
 
 .campaign-view-toggle:hover {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -2561,6 +2561,7 @@ h5 {
 .timeline-upper {
   background-color: transparent;
   gap: 15px;
+  margin-bottom: 50px;
 }
 
 .timeline-overview {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1581,13 +1581,54 @@ h5 {
   display: flex;
   align-items: center;
   text-align: left;
-  width: 90%;
 }
 
 .campaigns-heading {
   text-transform: uppercase;
   font-weight: 700;
   padding: 0;
+}
+
+.view-toggles {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  border: 1px solid var(--dark_red);
+  border-radius: 3px;
+  margin-top: 25px;
+  padding: 1px;
+  transition: 0.15s;
+  background-color: var(--darker_red);
+}
+
+.campaign-view-toggle {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 5px;
+  cursor: pointer;
+  border: 1px solid var(--elem_dark);
+  box-sizing: border-box;
+  transition: 0.15s;
+  background-color: var(--elem_dark);
+  stroke: var(--darker_red);
+}
+
+.campaign-view-toggle:hover {
+  filter: brightness(120%);
+}
+
+.campaign-view-toggle:active {
+  filter: brightness(80%);
+}
+
+.radio-hidden {
+  opacity: 0;
+  margin: 0;
+  position: absolute;
+  height: 0;
+  width: 0;
 }
 
 .campaigns-divider {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -3485,6 +3485,7 @@ h5 {
   flex-direction: column;
   padding: 20px;
   background-color: var(--elem_mid);
+  border-radius: 5px;
 }
 
 .event-elem-centre {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1921,13 +1921,13 @@ h5 {
   gap: 5px;
   background-color: var(--elem_dark);
   color: var(--text_flavour);
-  width: 160px;
+  width: 100%;
   height: 30px;
   padding: 5px;
 }
 
 .deploy-button-first {
-  border-top: 1px solid var(--elem_border);
+  border-top: 1px solid var(--elem_dark);
 }
 
 .entry-buttons-deploy a {
@@ -1937,12 +1937,11 @@ h5 {
 .deploy-button:hover {
   background-color: var(--elem_bright);
   transition: 0.1s;
-  outline: 1px solid var(--elem_border);
 }
 
 .deploy-button:active {
   color: var(--bright_red);
-  background-color: var(--bright_red);
+  background-color: var(--dark_red);
 }
 
 /*  */

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -3853,6 +3853,8 @@ pre {
   height: auto !important;
   box-sizing: border-box;
   border: 1px solid var(--darker_red);
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
 }
 
 .user-image-area {
@@ -3872,10 +3874,12 @@ pre {
   font-weight: 500;
   background-color: var(--darker_red);
   height: 20px;
-  padding: 10px;
+  padding: 5px;
   text-transform: uppercase;
   clip-path: polygon(0 0,calc(100% - 10.00px) 0,100% 10.00px,100% 100%,0 100%);
   color: var(--text_header_contrast);
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
 }
 
 /* Event preview HTML elements */

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1811,6 +1811,7 @@ h5 {
   display: flex;
   gap: 15px;
   margin-bottom: 11px;
+  flex-wrap: wrap;
 }
 
 @media screen and (min-width: 1200px) {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1617,7 +1617,7 @@ h5 {
   border: 1px solid var(--elem_dark);
   box-sizing: border-box;
   transition: 0.15s;
-  background-color: var(--elem_dark);
+  background-color: var(--elem_bright);
   stroke: var(--darker_red);
 }
 
@@ -1632,11 +1632,11 @@ h5 {
 }
 
 .campaign-view-toggle:hover {
-  filter: brightness(120%);
+  filter: brightness(90%);
 }
 
 .campaign-view-toggle:active {
-  filter: brightness(80%);
+  filter: brightness(70%);
 }
 
 .radio-hidden {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1926,10 +1926,6 @@ h5 {
   padding: 5px;
 }
 
-.deploy-button-first {
-  border-top: 1px solid var(--elem_dark);
-}
-
 .entry-buttons-deploy a {
   text-decoration: none;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1590,13 +1590,21 @@ h5 {
 }
 
 .view-toggles {
-  display: flex;
+  display: none;
   flex-direction: row;
   justify-content: center;
   border: 1px solid var(--dark_red);
   border-radius: 3px;
   margin-top: 25px;
   transition: 0.15s;
+}
+
+@media screen and (min-width: 1200px) {
+
+  .view-toggles {
+    display: flex;
+  }
+  
 }
 
 .campaign-view-toggle {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1645,21 +1645,33 @@ h5 {
 }
 
 .campaigns-list {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: space-between;
   padding-left: 0;
   filter: drop-shadow(0px 3px 3px var(--elem_shadow));
+  gap: 50px;
+  margin-top: 50px;
 }
 
 .campaign-entry {
   display: flex;
   flex-direction: column;
   text-align: left;
-  margin-bottom: 50px;
-  background-color: var(--elem_mid);
-  clip-path: polygon(0 0, calc(100% - 15.00px) 0, 100% 15.00px, 100% 100%, 0 100%);
   border-radius: 5px;
 }
 
+
+
+.campaign-header-section {
+  display: flex;
+  flex-direction: row;
+}
+
 .campaign-header {
+  display: flex;
+  width: 100%;
   background-color: var(--darker_red);
   color: var(--text_header_contrast);
   margin: 0;
@@ -1670,16 +1682,21 @@ h5 {
   transition: 0.3s;
 }
 
-.campaign-header:hover {
-  background-color: var(--dark_red);
+.campaign-corner {
+  display: flex;
+  background-color: var(--darker_red);
+  width: 50px;
+  clip-path: polygon(0 0, calc(100% - 15.00px) 0, 100% 15.00px, 100% 100%, 0 100%);
 }
 
 .campaign-body {
   display: flex;
+  height: 100%;
   flex-direction: column;
   gap: 15px;
   padding: 20px 50px 20px 50px;
   box-sizing: border-box;
+  background-color: var(--elem_mid);
 }
 
 .campaign-entry-title {
@@ -1858,6 +1875,9 @@ h5 {
 }
 
 .last-edited-area {
+  display: flex;
+  justify-content: flex-end;
+  height: 100%;
   padding-bottom: 10px;
 }
 
@@ -1908,10 +1928,13 @@ h5 {
 }
 
 .entry-buttons-deploy {
+  position: absolute;
   height: 0px;
-  width: 160px;
+  width: 162px;
   overflow: hidden;
+  z-index: 1;
   transition: 0.3s ease-in;
+  box-sizing: border-box;
 }
 
 .deploy-button {
@@ -1924,6 +1947,7 @@ h5 {
   width: 100%;
   height: 30px;
   padding: 5px;
+  z-index: 1;
 }
 
 .entry-buttons-deploy a {

--- a/static/images/icons/grid_2.svg
+++ b/static/images/icons/grid_2.svg
@@ -1,0 +1,4 @@
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.5 20.5L3.5 13.5L20.5 13.5V20.5H3.5Z" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.5 10.5L3.5 3.5L20.5 3.5V10.5L3.5 10.5Z" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/static/images/icons/grid_4.svg
+++ b/static/images/icons/grid_4.svg
@@ -1,0 +1,6 @@
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.5 3.5H10.5V10.5H3.5V3.5Z" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.5 13.5H10.5V20.5H3.5V13.5Z" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.5 3.5H20.5V10.5H13.5V3.5Z" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.5 13.5H20.5V20.5H13.5V13.5Z" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/static/js/campaigns.js
+++ b/static/js/campaigns.js
@@ -61,48 +61,4 @@ buttons.forEach((button, index) => {
 });
 
 
-// Get the radio buttons
-const radioList = document.getElementById("campaign-toggle-list");
-const radioGrid = document.getElementById("campaign-toggle-grid");
 
-// Get campaigns list elements
-const campaignsList = document.getElementById("campaigns-list");
-const campaignsEntries = document.getElementsByClassName("campaign-entry")
-
-// Add event listener to each radio button
-radioList.addEventListener("click", toggleLabelBackground);
-radioGrid.addEventListener("click", toggleLabelBackground);
-
-// Add event listener for page load
-document.addEventListener("DOMContentLoaded", toggleLabelBackground);
-
-// Function to toggle label background
-function toggleLabelBackground() {
-  // Get the labels
-  const labelList = document.querySelector('label[for="campaign-toggle-list"]');
-  const labelGrid = document.querySelector('label[for="campaign-toggle-grid"]');
-
-
-
-  // Change label background based on checked status
-  if (radioList.checked) {
-    labelList.style.backgroundColor = "var(--elem_bright)";
-    labelGrid.style.backgroundColor = "";
-
-    // Set layout style
-    campaignsList.style.flexDirection = "column"
-    Array.from(campaignsEntries).forEach((entry) => {
-      entry.style.width = "100%";
-    });
-    
-  } else if (radioGrid.checked) {
-    labelList.style.backgroundColor = "";
-    labelGrid.style.backgroundColor = "var(--elem_bright)";
-
-    // Set layout style
-    campaignsList.style.flexDirection = "row"
-    Array.from(campaignsEntries).forEach((entry) => {
-      entry.style.width = "45%";
-    });
-  }
-}

--- a/static/js/campaigns.js
+++ b/static/js/campaigns.js
@@ -59,4 +59,29 @@ buttons.forEach((button, index) => {
 });
 
 
+// Get the radio buttons
+const radioList = document.getElementById("campaign-toggle-list");
+const radioGrid = document.getElementById("campaign-toggle-grid");
 
+// Add event listener to each radio button
+radioList.addEventListener("click", toggleLabelBackground);
+radioGrid.addEventListener("click", toggleLabelBackground);
+
+// Add event listener for page load
+document.addEventListener("DOMContentLoaded", toggleLabelBackground);
+
+// Function to toggle label background
+function toggleLabelBackground() {
+  // Get the labels
+  const labelList = document.querySelector('label[for="campaign-toggle-list"]');
+  const labelGrid = document.querySelector('label[for="campaign-toggle-grid"]');
+
+  // Change label background based on checked status
+  if (radioList.checked) {
+    labelList.style.backgroundColor = "var(--elem_bright)";
+    labelGrid.style.backgroundColor = "";
+  } else if (radioGrid.checked) {
+    labelList.style.backgroundColor = "";
+    labelGrid.style.backgroundColor = "var(--elem_bright)";
+  }
+}

--- a/static/js/campaigns.js
+++ b/static/js/campaigns.js
@@ -20,9 +20,10 @@ class Dropdown {
   }
   
   openDropdown() {
-    this.button.style.marginBottom = "0"
     this.button.style.transitionDelay = "0s"
     this.dropdown.style.height = "150px"
+    this.dropdown.style.border = "1px solid var(--dark_red)"
+    this.dropdown.style.borderTop = ""
     this.state = true
   }
 
@@ -34,6 +35,7 @@ class Dropdown {
     // Disable transition delay after 0.3s
   setTimeout(() => {
     this.button.style.transitionDelay = "0s";
+    this.dropdown.style.border = ""
   }, 300);
   }
 
@@ -63,6 +65,10 @@ buttons.forEach((button, index) => {
 const radioList = document.getElementById("campaign-toggle-list");
 const radioGrid = document.getElementById("campaign-toggle-grid");
 
+// Get campaigns list elements
+const campaignsList = document.getElementById("campaigns-list");
+const campaignsEntries = document.getElementsByClassName("campaign-entry")
+
 // Add event listener to each radio button
 radioList.addEventListener("click", toggleLabelBackground);
 radioGrid.addEventListener("click", toggleLabelBackground);
@@ -76,12 +82,27 @@ function toggleLabelBackground() {
   const labelList = document.querySelector('label[for="campaign-toggle-list"]');
   const labelGrid = document.querySelector('label[for="campaign-toggle-grid"]');
 
+
+
   // Change label background based on checked status
   if (radioList.checked) {
     labelList.style.backgroundColor = "var(--elem_bright)";
     labelGrid.style.backgroundColor = "";
+
+    // Set layout style
+    campaignsList.style.flexDirection = "column"
+    Array.from(campaignsEntries).forEach((entry) => {
+      entry.style.width = "100%";
+    });
+    
   } else if (radioGrid.checked) {
     labelList.style.backgroundColor = "";
     labelGrid.style.backgroundColor = "var(--elem_bright)";
+
+    // Set layout style
+    campaignsList.style.flexDirection = "row"
+    Array.from(campaignsEntries).forEach((entry) => {
+      entry.style.width = "45%";
+    });
   }
 }

--- a/static/js/campaigns_layout.js
+++ b/static/js/campaigns_layout.js
@@ -45,7 +45,7 @@ function toggleLayout() {
 
   function setListLayout() {
     // Set button style
-    labelList.style.backgroundColor = "var(--elem_bright)";
+    labelList.style.backgroundColor = "var(--elem_dark)";
     labelGrid.style.backgroundColor = "";
 
     // Set layout style
@@ -58,7 +58,7 @@ function toggleLayout() {
   function setGridLayout() {
     // Set button style
     labelList.style.backgroundColor = "";
-    labelGrid.style.backgroundColor = "var(--elem_bright)";
+    labelGrid.style.backgroundColor = "var(--elem_dark)";
 
     // Set layout style
     campaignsList.style.flexDirection = "row"
@@ -69,21 +69,23 @@ function toggleLayout() {
 
   if (radioList.checked) {
 
-    setListLayout();
+    // Set user preference to "list"
     localStorage.setItem('campaign_layout', "list");
+
+    setListLayout();
     
   } else if (radioGrid.checked ) {
+
+    // Set user preference to "grid"
+    localStorage.setItem('campaign_layout', "grid");
 
     // Check if screen is wide enough to allow grid layout
     if (window.innerWidth >= 1200) {
       setGridLayout();
-      localStorage.setItem('campaign_layout', "grid");
     }
     // Otherwise, toggle back to list layout
     else {
-      radioList.checked = true;
-      radioGrid.checked = false;
-      toggleLayout();
+      setListLayout();
     }
     
 

--- a/static/js/campaigns_layout.js
+++ b/static/js/campaigns_layout.js
@@ -1,0 +1,73 @@
+// Get the radio buttons
+const radioList = document.getElementById("campaign-toggle-list");
+const radioGrid = document.getElementById("campaign-toggle-grid");
+
+// Get campaigns list elements
+const campaignsList = document.getElementById("campaigns-list");
+const campaignsEntries = document.getElementsByClassName("campaign-entry")
+
+// Add event listener to each radio button
+radioList.addEventListener("click", toggleLayout);
+radioGrid.addEventListener("click", toggleLayout);
+
+// Add event listener for page load and page refresh
+document.addEventListener("DOMContentLoaded", toggleLayout);
+window.addEventListener("resize", toggleLayout);
+
+
+// Function to toggle label background
+function toggleLayout() {
+
+  console.log("Function called")
+
+  // Get the labels
+  const labelList = document.querySelector('label[for="campaign-toggle-list"]');
+  const labelGrid = document.querySelector('label[for="campaign-toggle-grid"]');
+
+  function setListLayout() {
+    // Set button style
+    labelList.style.backgroundColor = "var(--elem_bright)";
+    labelGrid.style.backgroundColor = "";
+
+    // Set layout style
+    campaignsList.style.flexDirection = "column"
+    Array.from(campaignsEntries).forEach((entry) => {
+      entry.style.width = "100%";
+    });
+  }
+
+  function setGridLayout() {
+    // Set button style
+    labelList.style.backgroundColor = "";
+    labelGrid.style.backgroundColor = "var(--elem_bright)";
+
+    // Set layout style
+    campaignsList.style.flexDirection = "row"
+    Array.from(campaignsEntries).forEach((entry) => {
+      entry.style.width = "45%";
+    });
+  }
+
+  if (radioList.checked) {
+
+    setListLayout();
+    
+  } else if (radioGrid.checked ) {
+
+    // Check if screen is wide enough to allow grid layout
+    if (window.innerWidth >= 1200) {
+      setGridLayout();
+    }
+    // Otherwise, toggle back to list layout
+    else {
+      console.log("AAA")
+      radioList.checked = true;
+      radioGrid.checked = false;
+      toggleLayout();
+    }
+    
+
+  }
+
+
+}

--- a/static/js/campaigns_layout.js
+++ b/static/js/campaigns_layout.js
@@ -18,8 +18,6 @@ window.addEventListener("resize", toggleLayout);
 // Function to toggle label background
 function toggleLayout() {
 
-  console.log("Function called")
-
   // Get the labels
   const labelList = document.querySelector('label[for="campaign-toggle-list"]');
   const labelGrid = document.querySelector('label[for="campaign-toggle-grid"]');
@@ -60,7 +58,7 @@ function toggleLayout() {
     }
     // Otherwise, toggle back to list layout
     else {
-      console.log("AAA")
+      
       radioList.checked = true;
       radioGrid.checked = false;
       toggleLayout();

--- a/static/js/campaigns_layout.js
+++ b/static/js/campaigns_layout.js
@@ -10,10 +10,31 @@ const campaignsEntries = document.getElementsByClassName("campaign-entry")
 radioList.addEventListener("click", toggleLayout);
 radioGrid.addEventListener("click", toggleLayout);
 
-// Add event listener for page load and page refresh
+// Add event listener for page load
 document.addEventListener("DOMContentLoaded", toggleLayout);
+
+// Add event listener on page resize
 window.addEventListener("resize", toggleLayout);
 
+
+function getLocalStorage() {
+
+    // Check localstorage for previous set layout
+    previousLayout = localStorage.getItem('campaign_layout');
+
+    if (previousLayout == "grid") {
+      console.log("grid set")
+      radioList.checked = false;
+      radioGrid.checked = true;
+    }
+    else if (previousLayout == "list") {
+      console.log("list set")
+      radioList.checked = true;
+      radioGrid.checked = false;
+    }
+}
+
+getLocalStorage();
 
 // Function to toggle label background
 function toggleLayout() {
@@ -49,16 +70,17 @@ function toggleLayout() {
   if (radioList.checked) {
 
     setListLayout();
+    localStorage.setItem('campaign_layout', "list");
     
   } else if (radioGrid.checked ) {
 
     // Check if screen is wide enough to allow grid layout
     if (window.innerWidth >= 1200) {
       setGridLayout();
+      localStorage.setItem('campaign_layout', "grid");
     }
     // Otherwise, toggle back to list layout
     else {
-      
       radioList.checked = true;
       radioGrid.checked = false;
       toggleLayout();

--- a/templates/campaigns.html
+++ b/templates/campaigns.html
@@ -38,12 +38,17 @@
       {% include 'base/flash.html' %}
     </div>
 
-    <div class="campaigns-list">
+    <div id="campaigns-list" class="campaigns-list">
 
       {% for campaign in campaigns %}
         <section class="campaign-entry">
 
-          <h2 id="campaign-{{ campaign.id }}" class="campaign-header">{{ campaign.title }}</h2>
+          <div class="campaign-header-section">
+            <h2 id="campaign-{{ campaign.id }}" class="campaign-header">{{ campaign.title }}</h2>
+            <div class="campaign-corner"></div>
+          </div>
+
+
 
           <div class="campaign-body">
 
@@ -122,45 +127,43 @@
 
               {% if campaign in current_user.permissions %}
               
-                <div class = "dropdown-area">
+                <div class="dropdown-area">
 
                   <div class="entry-button-outline">
                     <button id="button-{{campaign.id}}" class="entry-button edit-button">EDIT</button>
-                  
-                      <div id="dropdown-{{campaign.id}}" class="entry-buttons-deploy">
-                        <a href="{{ url_for('campaign.edit_campaign', campaign_name=campaign.title, campaign_id=campaign.id)}}">
-                          <button class="deploy-button deploy-button-first">
-                            <img class="icon icon-small icon-invert" src="/static/images/icons/edit.svg"> 
-                            Title/Overview
-                          </button>
-                        </a>
-                        <a href="{{ url_for('campaign.edit_timeline', campaign_name=campaign.title, campaign_id=campaign.id)}}">
-                          <button class="deploy-button">
-                            <img class="icon icon-small icon-invert" src="/static/images/icons/docs.svg"> 
-                            Event Data
-                          </button>
-                        </a>
-                        <a href="{{ url_for('campaign.edit_campaign_users', campaign_name=campaign.title, campaign_id=campaign.id)}}">
-                          <button class="deploy-button">
-                            <img class="icon icon-small icon-invert" src="/static/images/icons/user_management_dark.svg"> 
-                            Members
-                          </button>
-                        </a>
-                        <a href="{{ url_for('data.backup_page', campaign_name=campaign.title, campaign_id=campaign.id) }}">
-                          <button class="deploy-button">
-                            <img class="icon icon-small icon-invert" src="/static/images/icons/database.svg"> 
-                            Data Backup
-                          </button>
-                        </a>
-                        <a href="{{ url_for('campaign.delete_campaign', campaign_name=campaign.title, campaign_id=campaign.id) }}">
-                          <button class="deploy-button deploy-button-last">
-                            <img class="icon icon-small icon-invert" src="/static/images/icons/bin.svg"> 
-                            Delete
-                          </button>
-                        </a>
-                      </div>   
-
-                    </div>
+                  </div>
+                  <div id="dropdown-{{campaign.id}}" class="entry-buttons-deploy">
+                    <a href="{{ url_for('campaign.edit_campaign', campaign_name=campaign.title, campaign_id=campaign.id)}}">
+                      <button class="deploy-button deploy-button-first">
+                        <img class="icon icon-small icon-invert" src="/static/images/icons/edit.svg"> 
+                        Title/Overview
+                      </button>
+                    </a>
+                    <a href="{{ url_for('campaign.edit_timeline', campaign_name=campaign.title, campaign_id=campaign.id)}}">
+                      <button class="deploy-button">
+                        <img class="icon icon-small icon-invert" src="/static/images/icons/docs.svg"> 
+                        Event Data
+                      </button>
+                    </a>
+                    <a href="{{ url_for('campaign.edit_campaign_users', campaign_name=campaign.title, campaign_id=campaign.id)}}">
+                      <button class="deploy-button">
+                        <img class="icon icon-small icon-invert" src="/static/images/icons/user_management_dark.svg"> 
+                        Members
+                      </button>
+                    </a>
+                    <a href="{{ url_for('data.backup_page', campaign_name=campaign.title, campaign_id=campaign.id) }}">
+                      <button class="deploy-button">
+                        <img class="icon icon-small icon-invert" src="/static/images/icons/database.svg"> 
+                        Data Backup
+                      </button>
+                    </a>
+                    <a href="{{ url_for('campaign.delete_campaign', campaign_name=campaign.title, campaign_id=campaign.id) }}">
+                      <button class="deploy-button deploy-button-last">
+                        <img class="icon icon-small icon-invert" src="/static/images/icons/bin.svg"> 
+                        Delete
+                      </button>
+                    </a>
+                  </div>  
                 </div>
 
               {% endif %}

--- a/templates/campaigns.html
+++ b/templates/campaigns.html
@@ -38,7 +38,7 @@
       {% include 'base/flash.html' %}
     </div>
 
-    <ul class="campaigns-list">
+    <div class="campaigns-list">
 
       {% for campaign in campaigns %}
         <section class="campaign-entry">
@@ -196,14 +196,14 @@
 
       {% endif %}
 
-      <!-- New Campaign Button -->
-      <a href="{{ url_for('campaign.create_campaign')}}" class="campaign-entry new-campaign-area">
-        <span class="new-campaign-span">
-        <h2 class="campaign-entry-title new-campaign-heading">New Campaign</h2>
-        </span>
-      </a>
+    </div>
 
-    </ul>
+    <!-- New Campaign Button -->
+    <a href="{{ url_for('campaign.create_campaign')}}" class="campaign-entry new-campaign-area">
+      <span class="new-campaign-span">
+      <h2 class="campaign-entry-title new-campaign-heading">New Campaign</h2>
+      </span>
+    </a>
 
   </div>
 </div>

--- a/templates/campaigns.html
+++ b/templates/campaigns.html
@@ -8,6 +8,27 @@
     
     <div class="campaigns-title">
       <h3 class="campaigns-heading heading-top">Campaigns</h1>
+      <div class="view-toggles">
+
+        <label class="toggle campaign-view-toggle" for="campaign-toggle-list">
+          <input class="radio radio-hidden" type="radio" id="campaign-toggle-list" name="view" value="HTML" checked>
+          <svg class="icon" width="20px" height="20px" viewBox="0 0 24 24" fill="none">
+            <path class="icon-colour-var" d="M3.5 20.5L3.5 13.5L20.5 13.5V20.5H3.5Z" stroke="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path class="icon-colour-var" d="M3.5 10.5L3.5 3.5L20.5 3.5V10.5L3.5 10.5Z" stroke="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </label>
+
+        <label class="toggle campaign-view-toggle" for="campaign-toggle-grid">
+          <input class="radio radio-hidden" type="radio" id="campaign-toggle-grid" name="view" value="HTML">
+          <svg class="icon" width="20px" height="20px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path class="icon-colour-var" d="M3.5 3.5H10.5V10.5H3.5V3.5Z" stroke="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path class="icon-colour-var" d="M3.5 13.5H10.5V20.5H3.5V13.5Z" stroke="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path class="icon-colour-var" d="M13.5 3.5H20.5V10.5H13.5V3.5Z" stroke="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path class="icon-colour-var" d="M13.5 13.5H20.5V20.5H13.5V13.5Z" stroke="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>       
+        </label>
+
+      </div>
     </div>
 
     <hr class="campaigns-divider">

--- a/templates/campaigns.html
+++ b/templates/campaigns.html
@@ -212,7 +212,8 @@
 </div>
 
 <!-- Javascript -->
-<script src="/static/js/campaigns.js"></script> 
+<script src="/static/js/campaigns.js"></script>
+<script src="/static/js/campaigns_layout.js"></script> 
 
 <!-- Scroll to target element if scroll_target is set -->
 {% if scroll_target %}

--- a/templates/campaigns.html
+++ b/templates/campaigns.html
@@ -10,7 +10,7 @@
       <h3 class="campaigns-heading heading-top">Campaigns</h1>
       <div class="view-toggles">
 
-        <label class="toggle campaign-view-toggle" for="campaign-toggle-list">
+        <label class="toggle campaign-view-toggle view-toggle-left" for="campaign-toggle-list">
           <input class="radio radio-hidden" type="radio" id="campaign-toggle-list" name="view" value="HTML" checked>
           <svg class="icon" width="20px" height="20px" viewBox="0 0 24 24" fill="none">
             <path class="icon-colour-var" d="M3.5 20.5L3.5 13.5L20.5 13.5V20.5H3.5Z" stroke="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -18,7 +18,7 @@
           </svg>
         </label>
 
-        <label class="toggle campaign-view-toggle" for="campaign-toggle-grid">
+        <label class="toggle campaign-view-toggle view-toggle-right" for="campaign-toggle-grid">
           <input class="radio radio-hidden" type="radio" id="campaign-toggle-grid" name="view" value="HTML">
           <svg class="icon" width="20px" height="20px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path class="icon-colour-var" d="M3.5 3.5H10.5V10.5H3.5V3.5Z" stroke="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
Adds a toggle button to the campaigns page, to adjust between list and grid layouts.

Layout toggle is hidden at screen widths below 1200px. The user selection is stored in localStorage, alowing persistence across the session. Layout choice reverts to list when resizing below 1200px width, but persists upon resizing larger once again.