### PR TITLE
Epoch Rework

### DIFF
--- a/app/forms/forms.py
+++ b/app/forms/forms.py
@@ -88,6 +88,7 @@ class CreateEpochForm(FlaskForm):
     description = TextAreaField("Description")
     submit = SubmitField("Create Epoch")
 
+
 class SearchUserForm(FlaskForm):
     username = StringField("Username", validators=[DataRequired()])
     submit = SubmitField("Search")

--- a/app/forms/validators.py
+++ b/app/forms/validators.py
@@ -45,5 +45,5 @@ def date_is_after(form, field):
         # The date_format validator will raise a Validation error already.
         return
 
-    if (start_year, start_month, start_day) >= (end_year, end_month, end_day):
+    if (start_year, start_month, start_day) > (end_year, end_month, end_day):
         raise ValidationError("End Date must be after Start Date")

--- a/app/forms/validators.py
+++ b/app/forms/validators.py
@@ -9,8 +9,8 @@ def date_format(format):
         message = "Not a valid date format, please use the format 'YYYY/MM/DD HH:MM:SS'"
         format = r"^-?\d{1,9}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}$"
     elif format == "epoch":
-        message = "Not a valid date format, please use the format 'YYYY/MM'"
-        format = r"^-?\d{1,9}/\d{2}$"
+        message = "Not a valid date format, please use the format 'YYYY/MM/DD'"
+        format = r"^-?\d{1,9}/\d{2}/\d{2}$"
 
     def _date_format(form, field):
 
@@ -39,11 +39,11 @@ def date_is_after(form, field):
 
     # Convert to integers, catching exception if incorrect format submitted
     try:
-        start_year, start_month = map(int, start_date.split("/"))
-        end_year, end_month = map(int, end_date.split("/"))
+        start_year, start_month, start_day = map(int, start_date.split("/"))
+        end_year, end_month, end_day = map(int, end_date.split("/"))
     except ValueError:
         # The date_format validator will raise a Validation error already.
         return
 
-    if start_year > end_year or (start_year == end_year and start_month > end_month):
-        raise ValidationError("End Date must be equal or after Start Date")
+    if (start_year, start_month, start_day) >= (end_year, end_month, end_day):
+        raise ValidationError("End Date must be after Start Date")

--- a/app/models/epoch.py
+++ b/app/models/epoch.py
@@ -4,7 +4,6 @@ from app import db
 from app.utils.sanitisers import sanitise_input
 
 
-
 class Epoch(db.Model):
     __tablename__ = "epoch"
 
@@ -29,12 +28,13 @@ class Epoch(db.Model):
     # An epoch is part of a campaign, and may encapsulate multiple events.
 
     campaign_id = db.Column(db.Integer, db.ForeignKey("campaign.id"))
-    parent_campaign = db.relationship("Campaign", back_populates="epochs")
+    parent_campaign = db.relationship("Campaign",
+                                      back_populates="epochs")
 
     # Many-to-many relationship to User, bypassing the `UserCampaign` class
     events = db.relationship("Event",
-                              secondary="epoch_events",
-                              back_populates="epochs")
+                             secondary="epoch_events",
+                             back_populates="epochs")
     
     # Methods
     def update(self, form, parent_campaign, new=False):
@@ -74,7 +74,6 @@ class Epoch(db.Model):
         self.populate_self()
         self.parent_campaign.check_epochs()
 
-
     @staticmethod
     def split_date(datestring):
         """ Method that splits a form datestring into individual integer values. """
@@ -84,7 +83,6 @@ class Epoch(db.Model):
         day = int(datestring.split("/")[2])
 
         return [year, month, day]
-
 
     def populate_self(self):
         """ Method to get all events in parent campaign that fall
@@ -112,8 +110,7 @@ class Epoch(db.Model):
                 return True
 
             return False
-        
-    
+
         self.events.clear()
         self.events = [event for event in self.parent_campaign.events if is_in_epoch(event, self)]
 

--- a/app/models/epoch.py
+++ b/app/models/epoch.py
@@ -101,11 +101,18 @@ class Epoch(db.Model):
             event_day = int(event.date.split("/")[2][:2])
 
             if epoch_start_year <= event_year <= epoch_end_year:
-                if epoch_start_month <= event_month <= epoch_end_month:
-                    if epoch_start_day <= event_day <= epoch_end_day:
-                        return True
-            else:
-                return False
+                if epoch_start_year == event_year and event_month < epoch_start_month:
+                    return False
+                if epoch_end_year == event_year and event_month > epoch_end_month:
+                    return False
+                if epoch_start_year == event_year and event_month == epoch_start_month and event_day < epoch_start_day:
+                    return False
+                if epoch_end_year == event_year and event_month == epoch_end_month and event_day > epoch_end_day:
+                    return False
+                return True
+
+            return False
+        
     
         self.events.clear()
         self.events = [event for event in self.parent_campaign.events if is_in_epoch(event, self)]

--- a/app/models/epoch.py
+++ b/app/models/epoch.py
@@ -50,11 +50,13 @@ class Epoch(db.Model):
                     self.start_date = value
                     self.start_year = self.split_date(value)[0]
                     self.start_month = self.split_date(value)[1]
+                    self.start_day = self.split_date(value)[2]
 
                 if field == "end_date":
                     self.end_date = value
                     self.end_year = self.split_date(value)[0]
                     self.end_month = self.split_date(value)[1]
+                    self.end_day = self.split_date(value)[2]
 
                 if field == "description":
                     value = sanitise_input(value)

--- a/app/models/epoch.py
+++ b/app/models/epoch.py
@@ -15,10 +15,12 @@ class Epoch(db.Model):
     start_date = db.Column(db.String, nullable=False)
     start_year = db.Column(db.Integer)
     start_month = db.Column(db.Integer)
+    start_day = db.Column(db.Integer)
 
     end_date = db.Column(db.String, nullable=False)
     end_year = db.Column(db.Integer)
     end_month = db.Column(db.Integer)
+    end_day = db.Column(db.Integer)
 
     description = db.Column(db.String(), nullable=True)
     has_events = db.Column(db.Boolean(), nullable=False, default=False)
@@ -71,13 +73,15 @@ class Epoch(db.Model):
         self.parent_campaign.check_epochs()
 
 
-    def split_date(self, datestring):
+    @staticmethod
+    def split_date(datestring):
         """ Method that splits a form datestring into individual integer values. """
 
         year = int(datestring.split("/")[0])
         month = int(datestring.split("/")[1])
+        day = int(datestring.split("/")[2])
 
-        return [year, month]
+        return [year, month, day]
 
 
     def populate_self(self):
@@ -87,17 +91,17 @@ class Epoch(db.Model):
         
         def is_in_epoch(event, epoch):
 
-            epoch_start_year = int(epoch.start_date.split("/")[:2][0])
-            epoch_start_month = int(epoch.start_date.split("/")[:2][1])
-            epoch_end_year = int(epoch.end_date.split("/")[:2][0])
-            epoch_end_month = int(epoch.end_date.split("/")[:2][1])
+            epoch_start_year, epoch_start_month, epoch_start_day = self.split_date(epoch.start_date)
+            epoch_end_year, epoch_end_month, epoch_end_day = self.split_date(epoch.end_date)
 
-            event_year = int(event.date.split("/")[:2][0])
-            event_month = int(event.date.split("/")[:2][1])
+            event_year = int(event.date.split("/")[0])
+            event_month = int(event.date.split("/")[1])
+            event_day = int(event.date.split("/")[2][:2])
 
             if epoch_start_year <= event_year <= epoch_end_year:
                 if epoch_start_month <= event_month <= epoch_end_month:
-                    return True
+                    if epoch_start_day <= event_day <= epoch_end_day:
+                        return True
             else:
                 return False
     

--- a/app/routes/epoch/routes.py
+++ b/app/routes/epoch/routes.py
@@ -30,8 +30,8 @@ def new_epoch(campaign_name, campaign_id):
         # Create placeholder event to prepopulate form
         epoch = models.Epoch()
 
-        epoch.start_date = request.args["date"]
-        epoch.end_date = request.args["date"]
+        epoch.start_date = request.args["date"] + "/01"
+        epoch.end_date = request.args["date"] + "/02"
         form = forms.CreateEpochForm(obj=epoch)
 
     # Otherwise, create default empty form

--- a/app/routes/epoch/routes.py
+++ b/app/routes/epoch/routes.py
@@ -83,6 +83,7 @@ def edit_epoch(campaign_name, campaign_id, epoch_title, epoch_id):
     session["timeline_scroll_target"] = f"epoch-{epoch.id}"
 
     form = forms.CreateEpochForm(obj=epoch)
+    delete_form = forms.SubmitForm()
 
     if form.validate_on_submit():
 
@@ -105,12 +106,13 @@ def edit_epoch(campaign_name, campaign_id, epoch_title, epoch_id):
                            campaign=campaign,
                            campaign_name=campaign.url_title,
                            form=form,
+                           delete_form=delete_form,
                            epoch=epoch,
                            edit_page=True)
 
 
 # Delete epoch
-@bp.route("/campaigns/<campaign_name>-<campaign_id>/epoch/<epoch_title>-<epoch_id>/delete", methods=["GET", "POST"])
+@bp.route("/campaigns/<campaign_name>-<campaign_id>/epoch/<epoch_title>-<epoch_id>/delete", methods=["POST"])
 @login_required
 def delete_epoch(campaign_name, campaign_id, epoch_title, epoch_id):
 

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -3439,6 +3439,10 @@ p {
   margin: 0px;
 }
 
+.hidden {
+  visibility: hidden;
+}
+
 /* Epoch */
 
 .epoch-outer {

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -3445,8 +3445,15 @@ p {
 
 /* Epoch */
 
+.epoch-start-group {
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 0;
+}
+
 .epoch-outer {
   display: flex;
+  flex: 1 0 0;
   flex-direction: column;
   justify-content: center;
   align-items: center;

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -3572,7 +3572,7 @@ p {
 }
 
 .epoch-end-outer {
-  margin-bottom: 120px;
+  margin-bottom: 40px;
 }
 
 .epoch-end-text {

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -3488,6 +3488,7 @@ p {
 .epoch-date {
   font-size: min(3.5vw, 18px);
   margin: 0;
+  text-align: center;
 }
 
 .epoch-end-date {
@@ -3736,7 +3737,6 @@ p {
   align-items: center;
   height: 30px;
   min-width: 30%;
-  transition: 0.5s;
   margin-left: 1px;
   /* Add back 1 pixel margin taken by event-line-bottom negative margin */
 }

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -1946,7 +1946,7 @@ p {
   clip-path: polygon(0 0, 100% 0%, 100% 100%, 15px 100%, 0 calc(100% - 15.00px));
   margin-left: -40px;
   margin-bottom: -80px;
-  transform: translateX(min(361px, 100vw));
+  transform: translateX(min(360px, 100vw));
   transition: 0.15s;
 }
 
@@ -3667,6 +3667,17 @@ p {
   padding-bottom: 50px;
 }
 
+.missing-event-area {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.event-between-missing {
+  width: 100%;
+  padding-bottom: 0px;
+}
+
 .event-between-events {
   width: 100%;
 }
@@ -3692,7 +3703,6 @@ p {
 }
 
 .new-event-flavour {
-  flex: 2 0 0;
   width: auto;
   font-size: min(3vw, 11px);
 }
@@ -4129,6 +4139,11 @@ for selection in timeline_search.js */
     padding-bottom: 75px;
   }
 
+  .event-between-missing {
+    padding-bottom: 50px;
+    margin-top: 5.5px;
+  }
+  
   .timeline-year-header {
     justify-content: flex-start;
     font-size: min(10vw, 48px);
@@ -4138,16 +4153,21 @@ for selection in timeline_search.js */
     font-size: 18px;
   }
 
+  .month-connector {
+    flex: 0.5;
+    min-width: 0px;
+  }
+
+  .hidden-mobile {
+    display: none;
+  }
+
   .connector-date {
     display: none;
   }
 
   .connector-date-outline {
     display: none;
-  }
-
-  .month-connector {
-    flex: 1 0 5vw;
   }
 
   .hidden-align {
@@ -4161,6 +4181,10 @@ for selection in timeline_search.js */
 
   .timeline-event {
     margin-top: -8px;
+  }
+
+  .epoch-elems {
+    width: 80%;
   }
 
 }

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -1586,6 +1586,7 @@ p {
   border-radius: 3px;
   margin: 0;
   padding: 8px;
+  cursor: pointer;
 }
 
 .user-delete-button {

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -4171,11 +4171,7 @@ for selection in timeline_search.js */
   .connector-date-outline {
     display: none;
   }
-
-  .hidden-align {
-    height: 0;
-  }
-
+  
   .event-header {
     padding: 9px 15px 10px 15px;
     font-size: 14px;

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -3704,7 +3704,7 @@ p {
 
 .new-event-flavour {
   width: auto;
-  font-size: min(3vw, 11px);
+  font-size: min(3vw, 12px);
 }
 
 .between-last {

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -923,9 +923,9 @@ p {
   width: 100%;
 }
 
-.timeline-showcase-scaledown {
+/* .timeline-showcase-scaledown {
   transform: scale(0.8);
-}
+} */
 
 .fade-group {
   opacity: 0;
@@ -3272,7 +3272,7 @@ p {
   flex: 1 0 0;
   margin-top: 50px;
   margin-bottom: 150px;
-  transition: 0.3s;
+  transition: all 0.25s ease 0s;
 }
 
 /* No Events found elements */

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -3501,6 +3501,7 @@ p {
   font-size: min(3.5vw, 18px);
   margin: 0;
   text-align: center;
+  white-space: nowrap;
 }
 
 .epoch-end-date {

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -4143,10 +4143,6 @@ for selection in timeline_search.js */
     height: 0;
   }
 
-  .epoch-start-marker, .epoch-end-marker {
-    opacity: 0;
-  }
-
   .event-header {
     padding: 9px 15px 10px 15px;
     font-size: 14px;

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -3657,7 +3657,7 @@ p {
   align-items: center;
   width: 25%;
   height: 20px;
-  margin-bottom: 50px;
+  padding-bottom: 50px;
 }
 
 .event-between-events {
@@ -4119,7 +4119,7 @@ for selection in timeline_search.js */
   }
 
   .event-between {
-    margin-bottom: 75px;
+    padding-bottom: 75px;
   }
 
   .timeline-year-header {

--- a/app/static/js/epoch_line_adjust.js
+++ b/app/static/js/epoch_line_adjust.js
@@ -53,7 +53,7 @@ function epochLineAdjust() {
 }
 
 // Trigger margin adjust on sidebar page element resize (usually from sidebar deployment)
-const element = document.getElementById("scrollpage");
+const element = document.getElementById("scrollpage") || document.getElementById("main-features");
 
 const resizeObserver = new ResizeObserver(entries => {
   entries.forEach(entry => {

--- a/app/static/js/epoch_line_adjust.js
+++ b/app/static/js/epoch_line_adjust.js
@@ -10,6 +10,7 @@ Array.from(dayLineFollowed).forEach(element => {
 
 function epochLineAdjust() {
 
+    // Adjust day vertical line lengths to compensate for epoch elements
     Array.from(dayLineFollowed).forEach((element, index) => {
         
         var dayElement = element.parentNode;
@@ -36,6 +37,18 @@ function epochLineAdjust() {
         
     });
 
+    // Adjust month connector margin-top to compensate for epoch elements
+    var monthConnectors = document.getElementsByClassName("month-connector-offset");
+    Array.from(monthConnectors).forEach(element => {
+        
+        var nextElement = element.nextElementSibling;
+        var epochElement = nextElement.querySelector(".epoch-start-group");
+        var epochHeight = epochElement.getBoundingClientRect().height;
+
+        element.style.marginTop = epochHeight + "px";
+
+    });
+
 }
 
 // Trigger margin adjust on sidebar page element resize (usually from sidebar deployment)
@@ -48,9 +61,6 @@ const resizeObserver = new ResizeObserver(entries => {
 });
 
 // Start observing the target element
-resizeObserver.observe(element);
-
-// Start observing the element
 resizeObserver.observe(element);
 
 // Add conventional event listeners for page load and resize

--- a/app/static/js/epoch_line_adjust.js
+++ b/app/static/js/epoch_line_adjust.js
@@ -1,0 +1,42 @@
+const dayLineFollowed = document.getElementsByClassName("day-line-followed");
+const startingMargins = []
+Array.from(dayLineFollowed).forEach(element => {
+
+    var computedStyle = window.getComputedStyle(element);
+    var marginBottom = parseFloat(computedStyle.getPropertyValue("margin-bottom"));
+    startingMargins.push(marginBottom)
+
+});
+
+function epochLineAdjust() {
+
+    Array.from(dayLineFollowed).forEach((element, index) => {
+        
+        var dayElement = element.parentNode;
+        var currentElement = dayElement.nextElementSibling;
+        var epochElements = [];
+
+        while (currentElement) {
+            if (currentElement.classList.contains("epoch-start-group") 
+            || currentElement.classList.contains("epoch-end-group")) {
+              epochElements.push(currentElement);
+            } else {
+              break;
+            }
+            currentElement = currentElement.nextElementSibling;
+          }
+
+          var totalHeight = 0;
+          for (var i = 0; i < epochElements.length; i++) {
+            totalHeight += epochElements[i].offsetHeight;
+          }
+
+        var newMargin = startingMargins[0] - totalHeight;
+        element.style.marginBottom = newMargin + "px";
+        
+    });
+
+}
+
+window.addEventListener("resize", epochLineAdjust);
+window.addEventListener("load", epochLineAdjust);

--- a/app/static/js/epoch_line_adjust.js
+++ b/app/static/js/epoch_line_adjust.js
@@ -19,7 +19,8 @@ function epochLineAdjust() {
 
         while (currentElement) {
             if (currentElement.classList.contains("epoch-start-group") 
-            || currentElement.classList.contains("epoch-end-group")) {
+            || currentElement.classList.contains("epoch-end-group")
+            || currentElement.classList.contains("event-between")) {
               epochElements.push(currentElement);
             } else {
               break;
@@ -29,7 +30,7 @@ function epochLineAdjust() {
 
           var totalHeight = 0;
           for (var i = 0; i < epochElements.length; i++) {
-            totalHeight += epochElements[i].offsetHeight;
+            totalHeight += epochElements[i].getBoundingClientRect().height;;
           }
 
         var newMargin = startingMargins[0] - totalHeight;

--- a/app/static/js/epoch_line_adjust.js
+++ b/app/static/js/epoch_line_adjust.js
@@ -38,5 +38,21 @@ function epochLineAdjust() {
 
 }
 
+// Trigger margin adjust on sidebar page element resize (usually from sidebar deployment)
+const element = document.getElementById("scrollpage");
+
+const resizeObserver = new ResizeObserver(entries => {
+  entries.forEach(entry => {
+    epochLineAdjust();
+  });
+});
+
+// Start observing the target element
+resizeObserver.observe(element);
+
+// Start observing the element
+resizeObserver.observe(element);
+
+// Add conventional event listeners for page load and resize
 window.addEventListener("resize", epochLineAdjust);
 window.addEventListener("load", epochLineAdjust);

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -28,7 +28,7 @@ class Tab {
   }
 
   checkScreenSize() {
-    if (window.innerWidth >= 1200 && this.state == true) {
+    if (window.innerWidth >= 1400 && this.state == true) {
       this.tab.style.marginRight = "300px";
     }
     else {

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -39,7 +39,7 @@ class Tab {
   openTab() {
     this.tab.style.transform = "translateX(300px)";
 
-    if (window.innerWidth >= 1200 ) {
+    if (window.innerWidth >= 1400 ) {
       this.tab.style.marginRight = "300px"
     }
 

--- a/app/static/js/timeline_search.js
+++ b/app/static/js/timeline_search.js
@@ -380,7 +380,7 @@ class SearchEngine {
             rightBranchLabel: dayContainer.querySelector(".right-branch-label"),
             eventGroupContainer: dayContainer.querySelector(".event-group-container"),
           },
-          dayLine: dayContainer.querySelector(".event-line"),
+          dayLine: dayContainer.querySelector(".day-line"),
           events: [],
           daysBelow: false,
           containsPositiveEvent: false,

--- a/app/static/js/timeline_search.js
+++ b/app/static/js/timeline_search.js
@@ -194,7 +194,10 @@ class Day {
   resetStyles() {
     this.elements["rightBranchLabel"].style.opacity = "";
     this.elements["eventGroupContainer"].style.opacity = "";
-    this.dayLine.style.opacity = "";
+
+    if (this.dayLine != null) {
+      this.dayLine.style.opacity = "";
+    }
 
     this.events.forEach(result => {
       result.styleReset();

--- a/app/templates/components/sidebar.html
+++ b/app/templates/components/sidebar.html
@@ -20,15 +20,15 @@
         
       {% for month in year.months %}
 
-        {% if month.has_epoch %}
-          {% for epoch in month.epochs %}
-          <a class="sidebar-button" href="#epoch-{{epoch.id}}">
-            <button class="event-button epoch-button">-{{epoch.title}}-</button>
-          </a>
-          {% endfor %}
-        {% endif %}
-
         {% for day in month.days %}
+
+          {% if day.has_epoch %}
+            {% for epoch in day.epochs %}
+            <a class="sidebar-button" href="#epoch-{{epoch.id}}">
+              <button class="event-button epoch-button">-{{epoch.title}}-</button>
+            </a>
+            {% endfor %}
+          {% endif %}
 
           {% for event in day.events  %}
             <a class="sidebar-button" href="#event-{{event.id}}">
@@ -42,21 +42,22 @@
             </a>
           {% endfor %}
 
-        {% endfor %}
+          {# Epoch End
 
-        {# Show Epoch End
+          {% if day.has_epoch_end %}
+            {% for epoch in day.end_epochs %}
+              {% if epoch.has_events %}
+              <a class="sidebar-button" href="#epoch-end-{{epoch.id}}">
+                <button class="event-button epoch-button">-End of {{epoch.title}}-</button>
+              </a>
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+          
+          #}
 
-        {% if month.has_epoch_end %}
-          {% for epoch in month.end_epochs %}
-            {% if epoch.has_events %}
-            <a class="sidebar-button" href="#epoch-end-{{epoch.id}}">
-              <button class="event-button epoch-button">-End of {{epoch.title}}-</button>
-            </a>
-            {% endif %}
-          {% endfor %}
-        {% endif %}
         
-        #}
+        {% endfor %}
 
       {% endfor %}
 

--- a/app/templates/components/timeline/day.html
+++ b/app/templates/components/timeline/day.html
@@ -82,6 +82,9 @@ elements.
     {% endif %}
   {% endif %}
 
+  {% if day.hide_marker %}
+    {% set hidden_class = "hidden" %}
+  {% endif %}
 
   <div class="right-branch-label">
 
@@ -92,7 +95,7 @@ elements.
           {{day.name}}
         </div>
       </div>
-      <div class="line line-spacer"></div>
+      <div class="line line-spacer {{ hidden_class }}"></div>
     </div>
 
   </div>

--- a/app/templates/components/timeline/day.html
+++ b/app/templates/components/timeline/day.html
@@ -49,7 +49,7 @@ elements.
 
   {% if edit %}
     {% if length == 1 %}
-    <div class="timeline-day-outer {{ month_hidden_class }}">
+    <div class="timeline-day-outer">
       <div class="day-line day-line-solo-edit {{ followed_by_epoch_class }}"></div>
     {% elif index == 0  %}
     <div class="timeline-day-outer">
@@ -89,8 +89,8 @@ elements.
     {% endif %}
   {% endif %}
 
-  <div class="right-branch-label {{ month_hidden_class }}">
 
+  <div class="right-branch-label">
     <div class="date-label-area {{ hidden_mobile_class}}">
       <div class="line line-first"></div>
       <div class="connector-date connector-date-outline">
@@ -101,7 +101,7 @@ elements.
       {% if edit and not day.has_events %}
       <div class="line line-spacer line-dashed"></div>
       {% else %}
-      <div class="line line-spacer {{ hidden_class}}"></div>
+      <div class="line line-spacer {{ hidden_class }}"></div>
       {% endif %}
     </div>
 
@@ -129,7 +129,7 @@ elements.
   {% endif %}
 
     {# All events within day #}
-    <div class="event-group-container {{ hidden_class }} {{ month_hidden_class }}">
+    <div class="event-group-container {{ hidden_class }}">
       {% for event in day.events %}
 
         {% if edit %}
@@ -163,7 +163,7 @@ elements.
 
   {% if edit and not day.has_following_day %}
     <!-- Between days event button -->
-    <div class="event-between event-between-days {{ month_hidden_class }}">
+    <div class="event-between event-between-days">
       <div class="between-days-elements">
         <div class="line line-dashed line-edit"></div>
     </div>

--- a/app/templates/components/timeline/day.html
+++ b/app/templates/components/timeline/day.html
@@ -36,7 +36,7 @@ elements.
   
   {# Give element "day-line-followed" class, which is targetted via js to
      extend line to meet element below #}
-  {% if day.followed_by_epoch %}
+  {% if day.followed_by_epoch and day.events | length != 0 %}
     {% set followed_by_epoch_class = "day-line-followed" %}
   {% endif %}
 

--- a/app/templates/components/timeline/day.html
+++ b/app/templates/components/timeline/day.html
@@ -1,3 +1,4 @@
+{% import "components/timeline/epoch.html" as epoch %}
 {% import "components/timeline/event.html" as timeline_event %}
 
 {# 
@@ -14,54 +15,70 @@ elements.
 
 {% macro day(campaign, year, month, day, length, index, edit=false) %}
 
+  {# Start of epoch markers #}
+  {% if day.has_epoch %}
+    {% if day.epoch_has_events %}
+      {% if edit %}
+        {{ epoch.epoch(day.epochs, campaign=campaign, contents=true, edit=true) }}
+      {% else %}
+        {{ epoch.epoch(day.epochs, campaign=campaign, contents=true, edit=false) }}
+      {% endif %}
+    {% else %}
+      {% if edit %}
+        {{ epoch.epoch(day.epochs, campaign=campaign, contents=false, edit=true) }}
+      {% else %}
+        {{ epoch.epoch(day.epochs, campaign=campaign, contents=false, edit=false) }}
+      {% endif %}
+    {% endif %}
+  {% endif %}
+
   <!-- Day {{ day.name }} -->
   
+  {# Give element "day-line-followed" class, which is targetted via js to
+     extend line to meet element below #}
+  {% if day.followed_by_epoch %}
+    {% set followed_by_epoch_class = "day-line-followed" %}
+  {% endif %}
+
   {% if edit %}
     {% if length == 1 %}
     <div class="timeline-day-outer">
-      <div class="day-line day-line-solo-edit"></div>
+      <div class="day-line day-line-solo-edit {{ followed_by_epoch_class }}"></div>
     {% elif index == 0  %}
     <div class="timeline-day-outer">
       {% if day.has_following_day %}
-      <div class="day-line day-line-top-edit top-no-between"></div>
+      <div class="day-line day-line-top-edit top-no-between {{ followed_by_epoch_class }}"></div>
       {% else %}
-      <div class="day-line day-line-top-edit"></div>
+      <div class="day-line day-line-top-edit {{ followed_by_epoch_class }}"></div>
       {% endif %}
-    {% elif index == length - 1 and length == 2 %}
-    <div class="timeline-day-outer day-container-edgecase">
-      <div class="day-line day-line-bottom-edit"></div>
     {% elif index == length - 1 %}
     <div class="timeline-day-outer day-container-bottom">
-      <div class="day-line day-line-bottom-edit"></div>
+      <div class="day-line day-line-bottom-edit {{ followed_by_epoch_class }}"></div>
     {% else %}
     <div class="timeline-day-outer day-container-mid">
       {% if day.has_following_day %}
-      <div class="day-line  day-line-mid-edit mid-no-between"></div>
+      <div class="day-line day-line-mid-edit mid-no-between {{ followed_by_epoch_class }}"></div>
       {% else %}
-      <div class="day-line  day-line-mid-edit"></div>
+      <div class="day-line day-line-mid-edit {{ followed_by_epoch_class }}"></div>
       {% endif %}
     {% endif %}
   {% else %}
     {# If day is the only day in the month #}
     {% if length == 1 %}
       <div class="timeline-day-outer">
-        <div class="day-line day-line-solo"></div>
+        <div class="day-line day-line-solo {{ followed_by_epoch_class }}"></div>
     {# If day is the first in the month #}
     {% elif index == 0  %}
     <div class="timeline-day-outer">
-      <div class="day-line day-line-top"></div>
-    {# If day is the last in the month and there are only two days #}
-    {% elif index == length - 1 and length == 2 %}
-    <div class="timeline-day-outer day-container-edgecase">
-      <div class="day-line day-line-bottom"></div>
+      <div class="day-line day-line-top {{ followed_by_epoch_class }}"></div>
     {# If the day is the last in the month #}
     {% elif index == length - 1 %}
       <div class="timeline-day-outer day-container-bottom">
-        <div class="day-line day-line-bottom"></div>
+        <div class="day-line day-line-bottom {{ followed_by_epoch_class }}"></div>
     {# All other days #}
     {% else %}
       <div class="timeline-day-outer day-container-mid">
-        <div class="day-line day-line-mid"></div>
+        <div class="day-line day-line-mid {{ followed_by_epoch_class }}"></div>
     {% endif %}
   {% endif %}
 
@@ -132,5 +149,14 @@ elements.
 
     </div>
   {% endif %}
+
+{# End of epoch markers #}
+{% if day.has_epoch_end %}
+  {% if day.epoch_has_events %}
+    {{ epoch.epoch_end(day.end_epochs) }}
+  {% else %}
+    {{ epoch.epoch_end(day.end_epochs, contents=false) }}
+  {% endif %}
+{% endif %}
 
 {%- endmacro %}

--- a/app/templates/components/timeline/day.html
+++ b/app/templates/components/timeline/day.html
@@ -53,7 +53,7 @@ elements.
       {% endif %}
     {% elif index == length - 1 %}
     <div class="timeline-day-outer day-container-bottom">
-      <div class="day-line day-line-bottom-edit {{ followed_by_epoch_class }}"></div>
+      <div class="day-line day-line-bottom-edit"></div>
     {% else %}
     <div class="timeline-day-outer day-container-mid">
       {% if day.has_following_day %}
@@ -74,7 +74,7 @@ elements.
     {# If the day is the last in the month #}
     {% elif index == length - 1 %}
       <div class="timeline-day-outer day-container-bottom">
-        <div class="day-line day-line-bottom {{ followed_by_epoch_class }}"></div>
+        <div class="day-line day-line-bottom"></div>
     {# All other days #}
     {% else %}
       <div class="timeline-day-outer day-container-mid">

--- a/app/templates/components/timeline/day.html
+++ b/app/templates/components/timeline/day.html
@@ -33,6 +33,13 @@ elements.
   {% endif %}
 
   <!-- Day {{ day.name }} -->
+  {% if not day.has_events %}
+    {% set hidden_class = "hidden" %}
+    {% set hidden_mobile_class = "hidden-mobile" %}
+  {% endif %}
+  {% if not month.has_events %}
+    {% set month_hidden_class = "hidden" %}
+  {% endif %}
   
   {# Give element "day-line-followed" class, which is targetted via js to
      extend line to meet element below #}
@@ -42,7 +49,7 @@ elements.
 
   {% if edit %}
     {% if length == 1 %}
-    <div class="timeline-day-outer">
+    <div class="timeline-day-outer {{ month_hidden_class }}">
       <div class="day-line day-line-solo-edit {{ followed_by_epoch_class }}"></div>
     {% elif index == 0  %}
     <div class="timeline-day-outer">
@@ -82,26 +89,47 @@ elements.
     {% endif %}
   {% endif %}
 
-  {% if day.hide_marker %}
-    {% set hidden_class = "hidden" %}
-  {% endif %}
+  <div class="right-branch-label {{ month_hidden_class }}">
 
-  <div class="right-branch-label">
-
-    <div class="date-label-area">
+    <div class="date-label-area {{ hidden_mobile_class}}">
       <div class="line line-first"></div>
       <div class="connector-date connector-date-outline">
         <div class="connector-date">
           {{day.name}}
         </div>
       </div>
-      <div class="line line-spacer {{ hidden_class }}"></div>
+      {% if edit and not day.has_events %}
+      <div class="line line-spacer line-dashed"></div>
+      {% else %}
+      <div class="line line-spacer {{ hidden_class}}"></div>
+      {% endif %}
     </div>
 
   </div>
 
+  {% if edit and not day.has_events %}
+    <div class="missing-event-area">
+      <div class="event-between event-between-missing">
+        
+        <div class="between-events-elements">
+          <div class="line line-dashed line-edit"></div>
+        </div>
+        <a href="{{ url_for('event.add_event', 
+                    campaign_name=campaign.url_title,
+                    campaign_id=campaign.id, 
+                    date=year.name + '/' + month.name + '/' + day.name + ' 00:00:00') }}">
+          <button id="new_event-{{year.name}}-{{month.name}}" class="new-timeline-item timeline-between-events">
+            <img class="icon icon-invert" src="/static/images/icons/plus.svg">
+          </button>
+        </a>
+        <p class="flavour-text new-event-flavour">//NEW EVENT: Missing Event</p>
+
+      </div>
+    </div>
+  {% endif %}
+
     {# All events within day #}
-    <div class="event-group-container">
+    <div class="event-group-container {{ hidden_class }} {{ month_hidden_class }}">
       {% for event in day.events %}
 
         {% if edit %}
@@ -135,7 +163,7 @@ elements.
 
   {% if edit and not day.has_following_day %}
     <!-- Between days event button -->
-    <div class="event-between event-between-days">
+    <div class="event-between event-between-days {{ month_hidden_class }}">
       <div class="between-days-elements">
         <div class="line line-dashed line-edit"></div>
     </div>
@@ -152,6 +180,8 @@ elements.
 
     </div>
   {% endif %}
+
+  
 
 {# End of epoch markers #}
 {% if day.has_epoch_end %}

--- a/app/templates/components/timeline/epoch.html
+++ b/app/templates/components/timeline/epoch.html
@@ -30,7 +30,7 @@ property to represent if the epoch has child events.
           <h3 class="epoch-header">{{ epoch.title }}</h3>
           <div class="epoch-body">
             {% if epoch.start_date != epoch.end_date %}
-              <h4 class="epoch-date">{{ epoch.start_date }} > {{ epoch.end_date }}</h4>
+              <h4 class="epoch-date">{{ epoch.start_date }} - {{ epoch.end_date }}</h4>
             {% else %}
               <h4 class="epoch-date">{{ epoch.start_date }}</h4>
             {% endif %}

--- a/app/templates/components/timeline/epoch.html
+++ b/app/templates/components/timeline/epoch.html
@@ -47,12 +47,10 @@ property to represent if the epoch has child events.
 
     </div>
 
-    {% if contents %}
       <div class="epoch-start-marker">
         <div class="epoch-vert-line"></div>
         <div class="epoch-hor-line"></div>
       </div>
-    {% endif %}
 
   </div>
 
@@ -72,12 +70,12 @@ Takes an a months epochs list as an argument
 {% macro epoch_end(epochs, contents=true) %}
 
 <div class="epoch-end-group">
-  {% if contents %}
+  
     <div class="epoch-end-marker">
       <div class="epoch-hor-line-end"></div>
       <div class="epoch-vert-line"></div>
     </div>
-  {% endif %}
+
 
   <div class="epoch-outer epoch-end-outer">
 

--- a/app/templates/components/timeline/epoch.html
+++ b/app/templates/components/timeline/epoch.html
@@ -30,7 +30,7 @@ property to represent if the epoch has child events.
           <h3 class="epoch-header">{{ epoch.title }}</h3>
           <div class="epoch-body">
             {% if epoch.start_date != epoch.end_date %}
-              <h4 class="epoch-date">{{ epoch.start_date }} - {{ epoch.end_date }}</h4>
+              <h4 class="epoch-date">{{ epoch.start_date }} > {{ epoch.end_date }}</h4>
             {% else %}
               <h4 class="epoch-date">{{ epoch.start_date }}</h4>
             {% endif %}

--- a/app/templates/components/timeline/epoch.html
+++ b/app/templates/components/timeline/epoch.html
@@ -13,45 +13,48 @@ property to represent if the epoch has child events.
 
 {% macro epoch(epochs, campaign, edit=false, contents=true) %}
 
-  <div class="epoch-outer">
+  <div class="epoch-start-group">
+    <div class="epoch-outer">
 
-    <div class="epoch-elems">
-    {% for epoch in epochs %}
-      {% if edit %}
-      <a class="edit-epoch" href="{{ url_for('epoch.edit_epoch', 
-                                     campaign_name=campaign.url_title,
-                                     campaign_id=campaign.id,
-                                     epoch_title=epoch.title,
-                                     epoch_id=epoch.id) }}">
-      {% endif %}
+      <div class="epoch-elems">
+      {% for epoch in epochs %}
+        {% if edit %}
+        <a class="edit-epoch" href="{{ url_for('epoch.edit_epoch', 
+                                      campaign_name=campaign.url_title,
+                                      campaign_id=campaign.id,
+                                      epoch_title=epoch.title,
+                                      epoch_id=epoch.id) }}">
+        {% endif %}
 
-      <div id="epoch-{{epoch.id}}" class="epoch-container">
-        <h3 class="epoch-header">{{ epoch.title }}</h3>
-        <div class="epoch-body">
-          {% if epoch.start_date != epoch.end_date %}
-            <h4 class="epoch-date">{{ epoch.start_date }} > {{ epoch.end_date }}</h4>
-          {% else %}
-            <h4 class="epoch-date">{{ epoch.start_date }}</h4>
-          {% endif %}
-          <h6 class="epoch-description">{{ epoch.description | safe }}</h6>
+        <div id="epoch-{{epoch.id}}" class="epoch-container">
+          <h3 class="epoch-header">{{ epoch.title }}</h3>
+          <div class="epoch-body">
+            {% if epoch.start_date != epoch.end_date %}
+              <h4 class="epoch-date">{{ epoch.start_date }} > {{ epoch.end_date }}</h4>
+            {% else %}
+              <h4 class="epoch-date">{{ epoch.start_date }}</h4>
+            {% endif %}
+            <h6 class="epoch-description">{{ epoch.description | safe }}</h6>
+          </div>
         </div>
+
+        {% if edit %}
+        </a>
+        {% endif %}
+      {% endfor %}
+
       </div>
 
-      {% if edit %}
-      </a>
-      {% endif %}
-    {% endfor %}
-
     </div>
+
+    {% if contents %}
+      <div class="epoch-start-marker">
+        <div class="epoch-vert-line"></div>
+        <div class="epoch-hor-line"></div>
+      </div>
+    {% endif %}
 
   </div>
-
-  {% if contents %}
-    <div class="epoch-start-marker">
-      <div class="epoch-vert-line"></div>
-      <div class="epoch-hor-line"></div>
-    </div>
-  {% endif %}
 
 {%- endmacro %}
 
@@ -68,6 +71,7 @@ Takes an a months epochs list as an argument
 
 {% macro epoch_end(epochs, contents=true) %}
 
+<div class="epoch-end-group">
   {% if contents %}
     <div class="epoch-end-marker">
       <div class="epoch-hor-line-end"></div>
@@ -87,6 +91,6 @@ Takes an a months epochs list as an argument
 
   </div>
 
-  
+</div>
 
 {%- endmacro %}

--- a/app/templates/components/timeline/event.html
+++ b/app/templates/components/timeline/event.html
@@ -59,7 +59,7 @@ elements.
     <div class="right-branch-label">
       {# Hide time label if event is tagged with "hide_time" #}
       {% if event.hide_time %}
-        <div class="date-label-area hidden-align">
+        <div class="date-label-area">
           <div class="line line-first"></div>
           <div class="line line-spacer"></div>
         </div>

--- a/app/templates/components/timeline/month.html
+++ b/app/templates/components/timeline/month.html
@@ -50,7 +50,7 @@ elements.
 
   {% if month.days | length != 0 %}
 
-    {% if month.hide_marker %}
+    {% if not month.has_events %}
       {% set hidden_class = "hidden" %}
     {% endif %}
 

--- a/app/templates/components/timeline/month.html
+++ b/app/templates/components/timeline/month.html
@@ -50,7 +50,11 @@ elements.
 
   {% if month.days | length != 0 %}
 
+    {% if month.epoch_offset %}
+    <div class="month-connector month-connector-offset">
+    {% else %}
     <div class="month-connector">
+    {% endif %}
 
       <div class="line line-first"></div>
       <div class="connector-date connector-date-outline">

--- a/app/templates/components/timeline/month.html
+++ b/app/templates/components/timeline/month.html
@@ -43,7 +43,7 @@ elements.
                             campaign_name=campaign.url_title,
                             campaign_id=campaign.id,
                             date=year.name + '/' + month.name) }}">
-        <button id="new_event-{{year.name}}-{{month.name}}" class="new-timeline-item">
+        <button id="new_epoch-{{year.name}}-{{month.name}}" class="new-timeline-item">
           <div class="epoch-button-text">NEW EPOCH
             <div>{{ year.name }} / {{month.name}}</div>
           </div>

--- a/app/templates/components/timeline/month.html
+++ b/app/templates/components/timeline/month.html
@@ -40,6 +40,11 @@ elements.
 
   <!-- Month {{ month.name }} -->
 
+  {% if not month.has_events %}
+    {% set hidden_class = "hidden" %}
+    {% set hidden_mobile_class = "hidden-mobile" %}
+  {% endif %}
+
   {% if index == 0 %}
     <div class="month-outer month-outer-top">
   {% elif index == length - 1 %}
@@ -50,14 +55,10 @@ elements.
 
   {% if month.days | length != 0 %}
 
-    {% if not month.has_events %}
-      {% set hidden_class = "hidden" %}
-    {% endif %}
-
     {% if month.epoch_offset %}
-    <div class="month-connector month-connector-offset {{ hidden_class }}">
+    <div class="month-connector month-connector-offset {{ hidden_mobile_class }}">
     {% else %}
-    <div class="month-connector {{ hidden_class }}">
+    <div class="month-connector {{ hidden_mobile_class }}">
     {% endif %}
 
       <div class="line line-first"></div>

--- a/app/templates/components/timeline/month.html
+++ b/app/templates/components/timeline/month.html
@@ -15,23 +15,6 @@ elements.
 
 {% macro month(campaign, year, month, day, length, index, edit=false) %}
 
-  {# Start of epoch markers #}
-  {% if month.has_epoch %}
-    {% if month.epoch_has_events %}
-      {% if edit %}
-        {{ epoch.epoch(month.epochs, campaign=campaign, contents=true, edit=true) }}
-      {% else %}
-        {{ epoch.epoch(month.epochs, campaign=campaign, contents=true, edit=false) }}
-      {% endif %}
-    {% else %}
-      {% if edit %}
-        {{ epoch.epoch(month.epochs, campaign=campaign, contents=false, edit=true) }}
-      {% else %}
-        {{ epoch.epoch(month.epochs, campaign=campaign, contents=false, edit=false) }}
-      {% endif %}
-    {% endif %}
-  {% endif %}
-
   {% if edit %}
     {# New Epoch Element #}
     <div class="epoch-between">
@@ -148,16 +131,5 @@ elements.
     {% endif %}
 
   {% endif %}
-
-    
-  {# End of epoch markers #}
-  {% if month.has_epoch_end %}
-    {% if month.epoch_has_events %}
-      {{ epoch.epoch_end(month.end_epochs) }}
-    {% else %}
-      {{ epoch.epoch_end(month.end_epochs, contents=false) }}
-    {% endif %}
-  {% endif %}
-
 
 {%- endmacro %}

--- a/app/templates/components/timeline/month.html
+++ b/app/templates/components/timeline/month.html
@@ -50,10 +50,14 @@ elements.
 
   {% if month.days | length != 0 %}
 
+    {% if month.hide_marker %}
+      {% set hidden_class = "hidden" %}
+    {% endif %}
+
     {% if month.epoch_offset %}
-    <div class="month-connector month-connector-offset">
+    <div class="month-connector month-connector-offset {{ hidden_class }}">
     {% else %}
-    <div class="month-connector">
+    <div class="month-connector {{ hidden_class }}">
     {% endif %}
 
       <div class="line line-first"></div>

--- a/app/templates/components/timeline_demo.html
+++ b/app/templates/components/timeline_demo.html
@@ -23,7 +23,7 @@
 
       <div class="epoch-elems">
         <div id="epoch-14" class="epoch-container">
-          <h3 class="epoch-header">Session 1</h3>
+          <h3 class="epoch-header">Mission 1</h3>
           <div class="epoch-body">
             
               <h4 class="epoch-date">5016/03</h4>
@@ -195,7 +195,7 @@
    <div class="epoch-outer epoch-end-outer fade-group fade-group-8">
       <div class="epoch-container">
          <div class="epoch-body">
-            <h6 id="epoch-end-11" class="epoch-end-text epoch-description">End of Session 1</h6>
+            <h6 id="epoch-end-11" class="epoch-end-text epoch-description">End of Mission 1</h6>
          </div>
       </div>
    </div>

--- a/app/templates/components/timeline_demo.html
+++ b/app/templates/components/timeline_demo.html
@@ -19,39 +19,69 @@
 </div>
 <div class="timeline-months-container">
 
-   <div class="epoch-outer fade-group fade-group-8">
+   <!-- Phase Start -->
+   <!-- <div class="epoch-start-group">
+      <div class="epoch-outer fade-group fade-group-8">
 
-      <div class="epoch-elems">
-        <div id="epoch-14" class="epoch-container">
-          <h3 class="epoch-header">Mission 1</h3>
-          <div class="epoch-body">
-            
-              <h4 class="epoch-date">5016/03</h4>
-            
-            <h6 class="epoch-description"></h6>
-          </div>
-        </div>
+         <div class="epoch-elems">
+           <div id="epoch-14" class="epoch-container">
+             <h3 class="epoch-header">Phase 1</h3>
+             <div class="epoch-body">
+               
+                 <h4 class="epoch-date">5016/01</h4>
+               
+               <h6 class="epoch-description">Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+                  sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+                  Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip 
+                  ex ea commodo consequat</h6>
+             </div>
+           </div>
+         </div>
       </div>
-   </div>
-
-   <div class="epoch-start-marker fade-group fade-group-8">
-      <div class="epoch-vert-line"></div>
-      <div class="epoch-hor-line"></div>
-   </div>
-
+   
+      <div class="epoch-start-marker fade-group fade-group-8">
+         <div class="epoch-vert-line"></div>
+         <div class="epoch-hor-line"></div>
+      </div>
+   </div> -->
+   
    <!-- Month 03 -->
    <div class="month-outer month-outer-top">
-      <div class="month-connector">
+      <div class="month-connector month-connector-offset">
          <div class="line line-first fade-group fade-group-2"></div>
          <div class="connector-date connector-date-outline fade-group fade-group-2">
             <div class="connector-date">
-               03
+               01
             </div>
          </div>
          <div class="line fade-group fade-group-3"></div>
       </div>
       <div class="timeline-month">
+
+         <div class="epoch-start-group">
+            <div class="epoch-outer fade-group fade-group-8">
+
+               <div class="epoch-elems">
+                 <div id="epoch-14" class="epoch-container">
+                   <h3 class="epoch-header">Mission 1</h3>
+                   <div class="epoch-body">
+                     
+                       <h4 class="epoch-date">5016/01/01 > 5016/01/02</h4>
+                     
+                     <h6 class="epoch-description"></h6>
+                   </div>
+                 </div>
+               </div>
+            </div>
+         
+            <div class="epoch-start-marker fade-group fade-group-8">
+               <div class="epoch-vert-line"></div>
+               <div class="epoch-hor-line"></div>
+            </div>
+         </div>
+
          <!-- Day 01 -->
+
          <div class="timeline-day-outer">
             <div class="day-line day-line-top fade-group fade-group-4"></div>
             <div class="right-branch-label">
@@ -81,7 +111,7 @@
                      </div>
                   </div>
                   <div class="event-outer-container">
-                     <h4 class="event-small-date">5016/03/01 22:00:00</h4>
+                     <h4 class="event-small-date">5016/01/01 22:00:00</h4>
                      <div class="timeline-event event-outline">
                         <div id="event-85" class="timeline-event">
                            <div class="event-header">
@@ -123,7 +153,7 @@
                      </div>
                   </div>
                   <div class="event-outer-container fade-group fade-group-5">
-                     <h4 class="event-small-date">5016/03/02 01:00:00</h4>
+                     <h4 class="event-small-date">5016/01/02 01:00:00</h4>
                      <div class="timeline-event event-outline">
                         <div id="event-86" class="timeline-event">
                            <div class="event-header">
@@ -148,7 +178,7 @@
                      </div>
                   </div>
                   <div class="event-outer-container fade-group fade-group-6">
-                     <h4 class="event-small-date">5016/03/02 07:30:00</h4>
+                     <h4 class="event-small-date">5016/01/02 07:30:00</h4>
                      <div class="timeline-event event-outline">
                         <div id="event-91" class="timeline-event">
                            <div class="event-header">
@@ -173,7 +203,7 @@
                      </div>
                   </div>
                   <div class="event-outer-container fade-group fade-group-7">
-                     <h4 class="event-small-date">5016/03/02 10:00:00</h4>
+                     <h4 class="event-small-date">5016/01/02 10:00:00</h4>
                      <div class="timeline-event event-outline">
                         <div id="event-90" class="timeline-event">
                            <div class="event-header">
@@ -185,19 +215,38 @@
                </div>
             </div>
          </div>
+
+         <div class="epoch-end-group">
+            <div class="epoch-end-marker fade-group fade-group-8">
+               <div class="epoch-hor-line-end"></div>
+               <div class="epoch-vert-line"></div>
+            </div>
+            <div class="epoch-outer epoch-end-outer fade-group fade-group-8">
+               <div class="epoch-container">
+                  <div class="epoch-body">
+                     <h6 id="epoch-end-11" class="epoch-end-text epoch-description">End of Mission 1</h6>
+                  </div>
+               </div>
+            </div>
+         </div>
+         
+         
       </div>
    </div>
 
-   <div class="epoch-end-marker fade-group fade-group-8">
-      <div class="epoch-hor-line-end"></div>
-      <div class="epoch-vert-line"></div>
-   </div>
-   <div class="epoch-outer epoch-end-outer fade-group fade-group-8">
-      <div class="epoch-container">
-         <div class="epoch-body">
-            <h6 id="epoch-end-11" class="epoch-end-text epoch-description">End of Mission 1</h6>
+   <!-- Phase End -->
+   <!-- <div class="epoch-end-group">
+      <div class="epoch-end-marker fade-group fade-group-8">
+         <div class="epoch-hor-line-end"></div>
+         <div class="epoch-vert-line"></div>
+      </div>
+      <div class="epoch-outer epoch-end-outer fade-group fade-group-8">
+         <div class="epoch-container">
+            <div class="epoch-body">
+               <h6 id="epoch-end-11" class="epoch-end-text epoch-description">End of Phase 1</h6>
+            </div>
          </div>
       </div>
-   </div>
+   </div> -->
 
 </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -47,7 +47,7 @@
         <div id="features-paragraph" class="features-paragraph hero-fade">
           <p>WAR/COR is a free, lightweight roleplaying game timeline creator, with a focus on
             structured, military campaign logging. Create and share session notes with your players,
-            document combat reports and track your campaign's history.
+            document combat reports and track your campaign's history with dynamically generated timelines.
           </p>
         </div>
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -130,6 +130,7 @@
 <script src="/static/js/index.js"></script>
 <script src="/static/js/carousel.js"></script>
 <script src="/static/js/margin_fix.js"></script> 
+<script src="/static/js/epoch_line_adjust.js"></script>
 <script>
   window.addEventListener("resize", marginFix);
   window.addEventListener('DOMContentLoaded', marginFix());

--- a/app/templates/new_epoch.html
+++ b/app/templates/new_epoch.html
@@ -77,7 +77,7 @@
             <p class="flavour-text">UWC-17-01 //  Epoch::Start Marker</p>
           </label>
         
-          {{ form.start_date(class_="campaign-input event-input", placeholder_="YYYY/MM REQUIRED", autocomplete="off") }}
+          {{ form.start_date(class_="campaign-input event-input", placeholder_="YYYY/MM/DD REQUIRED", autocomplete="off") }}
 
         </div>
 
@@ -94,11 +94,12 @@
               </div>
               <div class="modal-body">
                 <p>An epoch represents an era or a time period during a campaign.
-                  Epochs are placed at the month level within the timeline, and encapsulate 
+                  Epochs are placed at the day level within the timeline, and encapsulate 
                   all the events that take place within.
                 </p>
                 <p>An epoch can both contain other epochs and run parallel to them.</p>
-                <p>The epoch marker is placed at the beginning of the START DATE month.</p>
+                <p>The epoch marker is placed at the beginning of the START DATE day,
+                  and is inclusive of the END DATE day.</p>
               </div>
             </div>
           </div>
@@ -121,7 +122,7 @@
             <p class="flavour-text">UWC-17-02 //  Epoch::End Marker</p>
           </label>
         
-          {{ form.end_date(class_="campaign-input event-input", placeholder_="YYYY/MM REQUIRED", autocomplete="off") }}
+          {{ form.end_date(class_="campaign-input event-input", placeholder_="YYYY/MM/DD REQUIRED", autocomplete="off") }}
 
         </div>
 

--- a/app/templates/new_epoch.html
+++ b/app/templates/new_epoch.html
@@ -93,13 +93,13 @@
                 </span>
               </div>
               <div class="modal-body">
-                <p>An epoch represents an era or a time period during a campaign.
+                <p>An epoch represents an era or a time period during a campaign, grouping together
+                  any events that occur within the epoch start and end dates.
                   Epochs are placed at the day level within the timeline, and encapsulate 
                   all the events that take place within.
                 </p>
-                <p>An epoch can both contain other epochs and run parallel to them.</p>
-                <p>The epoch marker is placed at the beginning of the START DATE day,
-                  and is inclusive of the END DATE day.</p>
+                <p>The epoch markers are placed at the beginning of the START DATE day,
+                  and the end of the END DATE day.</p>
               </div>
             </div>
           </div>
@@ -139,7 +139,7 @@
               </div>
               <div class="modal-body">
                 <p>The END DATE of the epoch specifies the position of the end of epoch marker.</p>
-                <p>Events that occur within the END DATE month are considered part of the epoch.</p>
+                <p>Events that occur within the END DATE day are considered part of the epoch.</p>
               </div>
             </div>
           </div>
@@ -180,14 +180,17 @@
           {{ form.submit(class_="campaign-input campaign-submit", ) }}
         </div>  
           
+        {% if edit_page %}
+        <div class="fade-in-block-2 campaign-submit-area event-submit-area">
+          <button id="button-delete" class="campaign-input campaign-submit" type="button">
+            Delete Epoch
+          </button>
+        </div>
+        {% endif %} 
+
       </form>
 
       {% if edit_page %}
-        <div class="fade-in-block-2 campaign-submit-area event-submit-area">
-          <button id="button-delete" class="campaign-input campaign-submit">
-            Delete Epoch
-          </button>
-        </div> 
 
         {# Delete event confirm modal #}
 

--- a/app/templates/new_epoch.html
+++ b/app/templates/new_epoch.html
@@ -207,15 +207,14 @@
                 <p class="flavour-text modal-flavour">EPC-{{campaign.id}}-{{epoch.id}} // DELETION::CONFIRM</p>
                 <p class="modal-text modal-text-upper">Confirm termination of epoch: "{{epoch.title}}".</p>
 
-                <a class="delete-comment-link" href="{{ url_for('epoch.delete_epoch', 
+                <form method="POST" action="{{ url_for('epoch.delete_epoch',
                                                         campaign_name=campaign.url_title,
                                                         campaign_id=campaign.id,
                                                         epoch_title=epoch.title,
                                                         epoch_id=epoch.id) }}">
-                  <button class="button modal-confirm-button">
-                    DELETE
-                  </button>
-                </a>
+                  {{ delete_form.csrf_token }}
+                  {{ delete_form.submit(class_="button modal-confirm-button", value="DELETE") }}
+                </form>
 
               </div>
             </div>

--- a/app/templates/new_event.html
+++ b/app/templates/new_event.html
@@ -107,7 +107,7 @@
                 <p>In order to handle a variety of non-standard galactic calendars, WAR/COR does not
                   enforce standard year/month/day lengths.</p>
                 <p>The year value can be any value of 1-9 digits. A negative value may be given for the year, allowing the placement of events in a similar manner to the BC/BCE system.</p>
-                <p>The month, day, hour and seconds entries can be any value from 00-99, to accomodate any local galactic calendar standards.</p>
+                <p>The month, day, hour and seconds entries can be any value from 00-99, to accomodate any local system calendar standards.</p>
                 <p class="modal-highlight-text">Example: "5016/15/40 25:00:00" is a valid date.</p>
                 <p class="modal-highlight-text">Example: "-500/03/25 12:00:00" is a valid date.</p>
               </div>
@@ -322,15 +322,17 @@
           {{ form.submit(class_="button campaign-input campaign-submit") }}
         </div>  
   
-      </form>
-
-      {% if edit %}
+        {% if edit %}
         <div class="fade-in-block-2 campaign-submit-area event-submit-area">
-          <button id="button-delete" class="button campaign-input campaign-submit">
+          <button id="button-delete" class="button campaign-input campaign-submit" type="button">
             Delete Event
           </button>
         </div> 
+        {% endif %}
 
+      </form>
+
+      {% if edit %}
         {# Delete event confirm modal #}
 
         <div id="modal-delete" class="modal">

--- a/app/templates/password_reset.html
+++ b/app/templates/password_reset.html
@@ -41,14 +41,14 @@
                 <div class="auth-form-upper upper-recovery">
                   <div class="form-elem">
                     <label class="form-icon">
-                      <img class="icon icon-invert" src="/static/images/icons/email.svg">
+                      <img class="icon icon-invert" src="/static/images/icons/lock.svg">
                     </label>
                     {{ form.new_password(placeholder_="NEW_PASSWORD", class_='form-field', autocomplete='off') }}
                   </div>
 
                   <div class="form-elem">
                     <label class="form-icon">
-                      <img class="icon icon-invert" src="/static/images/icons/email.svg">
+                      <img class="icon icon-invert" src="/static/images/icons/lock_key.svg">
                     </label>
                     {{ form.confirm_password(placeholder_="CONFIRM_PASSWORD", class_='form-field', autocomplete='off') }}
                   </div>

--- a/app/templates/timeline.html
+++ b/app/templates/timeline.html
@@ -37,7 +37,7 @@
 <div class="sidebar-page">
   {% include "components/sidebar.html" %}
 
-  <div class="scrollpage">
+  <div id="scrollpage" class="scrollpage">
 
     <div class="campaigns-content">
 

--- a/app/templates/timeline.html
+++ b/app/templates/timeline.html
@@ -167,7 +167,6 @@
 
                   <div class="timeline-columns">
 
-                    {% if year.marker %}
                     <div id="timeline-left-marker" class="timeline-left-marker">
                       <div class="year-marker-hr"></div>
                       <div class="year-marker-line"></div>
@@ -175,15 +174,6 @@
                       <div class="year-marker-line"></div>
                       <div class="year-marker-hr"></div>
                     </div>
-                    {% else %}
-                    <div id="timeline-left-marker" class="timeline-left-marker marker-invis">
-                      <div class="year-marker-hr marker-invis"></div>
-                      <div class="year-marker-line marker-invis"></div>
-                      <h5 class="year-marker marker-invis">{{ year.name + campaign.date_suffix}}</h5>
-                      <div class="year-marker-line marker-invis"></div>
-                      <div class="year-marker-hr marker-invis"></div>
-                    </div>
-                    {% endif %}
 
                     <div class="timeline-right-marker">
                       <div class="timeline-horizontal"></div>
@@ -230,7 +220,8 @@
 {% endif %}
 <script src="/static/js/timeline_search.js"></script>
 <script src="/static/js/scroll_target.js"></script> 
-<script src="/static/js/margin_fix.js"></script> 
+<script src="/static/js/margin_fix.js"></script>
+<script src="/static/js/epoch_line_adjust.js"></script>
 <script>
   window.addEventListener("resize", marginFix);
   window.addEventListener('DOMContentLoaded', marginFix());

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -44,6 +44,11 @@ def event(client):
     return EventActions(client)
 
 
+@pytest.fixture()
+def epoch(client):
+    return EpochActions(client)
+
+
 class AuthActions(object):
     """ Class to facilitate common user auth functions during testing """
 
@@ -170,6 +175,20 @@ class EventActions(object):
                       campaign_id=campaign_object.id,
                       event_name=event_object.title,
                       event_id=event_object.id)
+
+        return self._client.post(url, data=data, follow_redirects=True)
+
+
+class EpochActions(object):
+
+    def __init__(self, client):
+        self._client = client
+
+    def create(self, campaign_object, data):
+
+        url = url_for("epoch.new_epoch",
+                      campaign_name=campaign_object.title,
+                      campaign_id=campaign_object.id)
 
         return self._client.post(url, data=data, follow_redirects=True)
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -192,6 +192,16 @@ class EpochActions(object):
 
         return self._client.post(url, data=data, follow_redirects=True)
 
+    def edit(self, campaign_object, epoch_object, data):
+
+        url = url_for("epoch.edit_epoch",
+                      campaign_name=campaign_object.title,
+                      campaign_id=campaign_object.id,
+                      epoch_id=epoch_object.id,
+                      epoch_title=epoch_object.title)
+
+        return self._client.post(url, data=data, follow_redirects=True)
+
 
 @pytest.fixture
 def captured_templates(app):

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -202,6 +202,16 @@ class EpochActions(object):
 
         return self._client.post(url, data=data, follow_redirects=True)
 
+    def delete(self, campaign_object, epoch_object):
+
+        url = url_for("epoch.delete_epoch",
+                      campaign_name=campaign_object.title,
+                      campaign_id=campaign_object.id,
+                      epoch_id=epoch_object.id,
+                      epoch_title=epoch_object.title)
+
+        return self._client.post(url, follow_redirects=True)
+
 
 @pytest.fixture
 def captured_templates(app):

--- a/app/tests/test_routes/test_epoch.py
+++ b/app/tests/test_routes/test_epoch.py
@@ -85,3 +85,27 @@ def test_edit_epoch(client, auth, epoch):
 
     assert epoch_object_edited is not None
     assert epoch_object_edited.title == "Test Epoch Edited"
+
+
+def test_delete_epoch(client, auth, epoch):
+
+    campaign_object = db.session.execute(
+        select(models.Campaign)
+        .filter_by(title="Test Campaign")).scalar()
+
+    epoch_object_edited = db.session.execute(
+        select(models.Epoch)
+        .filter_by(title="Test Epoch Edited")).scalar()
+
+    # Test epoch can be deleted
+    auth.login(username="Admin", password=TEST_PASSWORD)
+    response_1 = epoch.delete(campaign_object,
+                              epoch_object_edited)
+    assert response_1.status_code == 200
+
+    epoch_object_edited = db.session.execute(
+        select(models.Epoch)
+        .filter_by(title="Test Epoch Edited")).scalar()
+
+    assert epoch_object_edited is None
+    assert len(campaign_object.epochs) == 0

--- a/app/tests/test_routes/test_epoch.py
+++ b/app/tests/test_routes/test_epoch.py
@@ -53,3 +53,35 @@ def test_new_epoch(client, auth, epoch):
         .filter_by(title="Test Epoch")).scalar()
     assert epoch_object is not None
     assert epoch_object in campaign_object.epochs
+
+
+def test_edit_epoch(client, auth, epoch):
+
+    campaign_object = db.session.execute(
+        select(models.Campaign)
+        .filter_by(title="Test Campaign")).scalar()
+
+    epoch_object = db.session.execute(
+        select(models.Epoch)
+        .filter_by(title="Test Epoch")).scalar()
+
+    data = {
+        "start_date": "5017/01/01",
+        "end_date": "5017/01/03",
+        "title": "Test Epoch Edited",
+        "description": "Epoch description edited",
+    }
+
+    # Test that epoch can be edited
+    auth.login(username="Admin", password=TEST_PASSWORD)
+    response_1 = epoch.edit(campaign_object,
+                            epoch_object,
+                            data=data)
+    assert response_1.status_code == 200
+
+    epoch_object_edited = db.session.execute(
+        select(models.Epoch)
+        .filter_by(title="Test Epoch Edited")).scalar()
+
+    assert epoch_object_edited is not None
+    assert epoch_object_edited.title == "Test Epoch Edited"

--- a/app/tests/test_routes/test_epoch.py
+++ b/app/tests/test_routes/test_epoch.py
@@ -1,0 +1,55 @@
+from sqlalchemy import select
+from flask import url_for
+from app import db
+from app import models
+
+TEST_PASSWORD = "123456768"
+
+
+def test_setup(client, auth, campaign):
+    # Create test users
+    auth.register(email="testemail1@email.com",
+                  username="Admin",
+                  password=TEST_PASSWORD)
+    auth.logout()
+
+    # Create test campaign
+    auth.login(username="Admin", password=TEST_PASSWORD)
+    campaign.create(title="Test Campaign",
+                    description="A campaign for testing purposes")
+
+    campaign_object = db.session.execute(
+        select(models.Campaign)
+        .filter_by(title="Test Campaign")).scalar()
+
+    db.session.commit()
+
+
+def test_new_epoch(client, auth, epoch):
+
+    campaign_object = db.session.execute(
+        select(models.Campaign)
+        .filter_by(title="Test Campaign")).scalar()
+
+    data = {
+        "start_date": "5016/01/01",
+        "end_date": "5016/01/03",
+        "title": "Test Epoch",
+        "description": "Epoch description",
+    }
+
+    # Test that unauthenticated user cannot access route
+    response_1 = epoch.create(campaign_object, data)
+    assert response_1.status_code == 200
+    assert b'<li>Please log in to access this page</li>' in response_1.data
+
+    # Test that campaign admin can create epoch
+    auth.login(username="Admin", password=TEST_PASSWORD)
+    response_2 = epoch.create(campaign_object, data)
+    assert response_2.status_code == 200
+
+    epoch_object = db.session.execute(
+        select(models.Epoch)
+        .filter_by(title="Test Epoch")).scalar()
+    assert epoch_object is not None
+    assert epoch_object in campaign_object.epochs

--- a/app/tests/test_routes/test_session.py
+++ b/app/tests/test_routes/test_session.py
@@ -21,7 +21,6 @@ def test_check_consent(client, captured_templates):
 
     assert "consent" in context_2
     assert context_2["consent"] is False
-    assert "consent_form" in context_2
 
 
 # Test cookie acceptance route

--- a/app/utils/organisers.py
+++ b/app/utils/organisers.py
@@ -17,6 +17,7 @@ class Month:
     def __init__(self):
         self.name = ""
         self.days = []
+        self.has_events = False
         self.has_following_month = False
         self.epoch_offset = False
         self.hide_marker = False
@@ -30,6 +31,7 @@ class Day:
         self.has_following_day = False
         self.has_epoch = False
         self.has_epoch_end = False
+        self.has_events = False
         self.epochs = []
         self.end_epochs = []
         self.epoch_has_events = False
@@ -246,6 +248,9 @@ def campaign_sort(campaign):
                     if len(day_object.events) == 0:
                         day_object.hide_marker = True
 
+                if len(day_object.events) > 0:
+                    day_object.has_events = True
+
                 # Append the day object to the month object
                 month_object.days.append(day_object)
 
@@ -257,6 +262,9 @@ def campaign_sort(campaign):
 
                 if index == 0 and day_object.has_epoch:
                     month_object.epoch_offset = True
+
+                if day_object.has_events:
+                    month_object.has_events = True
 
             # Append the month object to the year object
             year_object.months.append(month_object)   

--- a/app/utils/organisers.py
+++ b/app/utils/organisers.py
@@ -18,6 +18,7 @@ class Month:
         self.name = ""
         self.days = []
         self.has_following_month = False
+        self.epoch_offset = False
 
 
 class Day:
@@ -221,16 +222,22 @@ def campaign_sort(campaign):
                                 "has_epoch_end", 
                                 day_object.end_epochs)
                 
+                # Flag day object as having epoch end element after it for
+                # template rendering
+                if day_object.has_epoch_end:
+                    day_object.followed_by_epoch = True
+
                 # Append the day object to the month object
                 month_object.days.append(day_object)
 
-            # Flag day objects if they have epoch elements after them
+            # Flag day objects if the next day has epoch elements before them
             # for template rendering purposes
             for index, day_object in enumerate(month_object.days):
                 if day_object.has_epoch and index != 0:
                     month_object.days[index - 1].followed_by_epoch = True
-                elif day_object.has_epoch_end:
-                    month_object.days[index].followed_by_epoch = True
+
+                if index == 0 and day_object.has_epoch:
+                    month_object.epoch_offset = True
 
             # Append the month object to the year object
             year_object.months.append(month_object)   

--- a/app/utils/organisers.py
+++ b/app/utils/organisers.py
@@ -1,5 +1,8 @@
 from itertools import groupby
 import copy
+from collections import defaultdict
+
+from app import db, models
 
 
 
@@ -9,7 +12,6 @@ class Year:
     def __init__(self):
         self.name = ""
         self.months = []
-        self.marker = False
 
 
 class Month:
@@ -17,11 +19,6 @@ class Month:
     def __init__(self):
         self.name = ""
         self.days = []
-        self.has_epoch = False
-        self.has_epoch_end = False
-        self.epochs = []
-        self.end_epochs = []
-        self.epoch_has_events = False
         self.has_following_month = False
 
 
@@ -31,6 +28,11 @@ class Day:
         self.name = ""
         self.events = []
         self.has_following_day = False
+        self.has_epoch = False
+        self.has_epoch_end = False
+        self.epochs = []
+        self.end_epochs = []
+        self.epoch_has_events = False
 
 
 def campaign_sort(campaign):
@@ -76,44 +78,50 @@ def campaign_sort(campaign):
         Other properties are also assigned here to assist in template rendering.
         
     """
-    
-    def custom_sort(event):
-        """Sort key function for sorting event objects """
-        return (event.year, event.month, event.day, event.hour, event.minute, event.second)
 
-    def check_year_marker(year):
-        """Check if a given year is long enough to warrant a year marker """
+    def create_dict(object_list, year_attr, month_attr, day_attr):
 
-        marker = False
-
-        if len(year) >= 3:
-            marker = True
+        dict = {}
+        for item_object in object_list:
             
-        for month in year:
-            if len(year[month]) >= 5:
-                marker = True
-            for day in year[month]:
-                if len(year[month][day]) >= 5:
-                    marker = True
-        
-        if marker:
-            return True
-        else:
-            return False
+            year = getattr(item_object, year_attr)
+            month = getattr(item_object, month_attr)
+            day = getattr(item_object, day_attr)
 
-    def group_epochs(epochs, sort_key, year_key, month_key):
-        """Function to sort epochs into matching data structure to the timeline events.
-        Takes a list of a campaigns epochs, as well as a sort key."""
-        sorted_epochs = sorted(epochs, key=sort_key)
-        epoch_groups = groupby(sorted_epochs, key=year_key)
-        grouped_epochs = {year: list(group) for year, group in epoch_groups}
+            if year not in dict:
+                dict[year] = {}
 
-        for year in grouped_epochs:
-            groups = groupby(grouped_epochs[year], key=month_key)
-            grouped_months = {month: list(group) for month, group in groups}
-            grouped_epochs[year] = grouped_months
+            if month not in dict[year]:
+                dict[year][month] = {}
 
-        return grouped_epochs
+            if day not in dict[year][month]:
+                dict[year][month][day] = []
+
+            dict[year][month][day].append(item_object)
+
+        return dict
+    
+
+    def merge_dicts(dict1, dict2):
+
+        combined_dict = copy.deepcopy(dict1)
+
+        for year in dict2:
+            if year in combined_dict:
+                for month in dict2[year]:
+                    if month in combined_dict[year]:
+                        for day in dict2[year][month]:
+                            if day in combined_dict[year][month]:
+                                pass
+                            else:
+                                combined_dict[year][month][day] = dict2[year][month][day]
+                    else:
+                        combined_dict[year][month] = dict2[year][month]
+            else:
+                combined_dict[year] = dict2[year]
+
+        return combined_dict
+
 
     def has_following(index, level, current_item):
         """ Function to determine if month/day within timeline has a consecutive following month/day.
@@ -150,73 +158,59 @@ def campaign_sort(campaign):
         else:
             return False
 
+
+    def check_for_epoch(dictionary, year, month, day, day_object, has_epoch_attr, epochs_attr):
+        try:
+            epochs = dictionary[year][month][day]
+        except KeyError:
+            pass
+        else:
+            setattr(day_object, has_epoch_attr, True)
+            for epoch in epochs:
+                epochs_attr.append(epoch)
+
+
     # --- START ---
 
-    # Sort and group epochs by start date and end date
-    epochs_by_start_date = group_epochs(campaign.epochs, 
-                                        sort_key=lambda epoch: (epoch.start_year, epoch.start_month),
-                                        year_key=lambda epoch: epoch.start_year,
-                                        month_key=lambda epoch: epoch.start_month)
-    epochs_by_end_date = group_epochs(campaign.epochs,
-                                      sort_key=lambda epoch: (epoch.end_year, epoch.end_month),
-                                      year_key=lambda epoch: epoch.end_year,
-                                      month_key=lambda epoch: epoch.end_month)
+    events = (db.session.query(models.Event)
+            .filter_by(campaign_id=campaign.id)
+            .order_by(models.Event.year, 
+                    models.Event.month, 
+                    models.Event.day)
+                    .all())
     
-    # Merge two dictionaries for year/month population
-    combined_epochs = {}
+    epochs_by_start_date = (db.session.query(models.Epoch)
+                            .filter_by(campaign_id=campaign.id)
+                            .order_by(models.Epoch.start_year,
+                                      models.Epoch.start_month,
+                                      models.Epoch.start_day)
+                                      .all())
+    
+    epochs_by_end_date = (db.session.query(models.Epoch)
+                          .filter_by(campaign_id=campaign.id)
+                          .order_by(models.Epoch.end_year,
+                                    models.Epoch.end_month,
+                                    models.Epoch.end_day)
+                                    .all())
 
-    for year in epochs_by_start_date:
-        if year not in combined_epochs:
-            combined_epochs[year] = epochs_by_start_date[year]
-    for year in epochs_by_end_date:
-        if year not in combined_epochs:
-            combined_epochs[year] = epochs_by_end_date[year]
+    year_dict = create_dict(object_list=events,
+                            year_attr="year",
+                            month_attr="month",
+                            day_attr="day")
+    
+    epoch_start_dict = create_dict(object_list=epochs_by_start_date,
+                                   year_attr="start_year",
+                                   month_attr="start_month",
+                                   day_attr="start_day")
+    
+    epoch_end_dict = create_dict(object_list=epochs_by_end_date,
+                                 year_attr="end_year",
+                                 month_attr="end_month",
+                                 day_attr="end_day")
 
-    # Sort years again
-    combined_epochs = {key: value for key, value in sorted(combined_epochs.items())}
+    combined_epochs_dict = merge_dicts(epoch_start_dict, epoch_end_dict)
 
-    # Current epoch structure:
-    # grouped_epochs = {year: {month: [<Epoch 1>, <Epoch 2>]}
-
-    # Sort events into date order
-    sorted_events = sorted(campaign.events, key=custom_sort)
-    # Structure events into dictionary, grouped by year
-    groups = groupby(sorted_events, key=lambda event: event.year)
-    grouped_events = {year: list(group) for year, group in groups}
-
-    # Group each years events into months
-    for year in grouped_events:
-        groups = groupby(grouped_events[year], key=lambda event: event.month)
-        grouped_months = {month: list(group) for month, group in groups}
-        grouped_events[year] = grouped_months
-
-    # Group each months events into days
-    for year in grouped_events:
-        for month in grouped_events[year]:
-            groups = groupby(grouped_events[year][month], key=lambda event: event.day)
-            grouped_days = {day: list(group) for day, group in groups}
-            grouped_events[year][month] = grouped_days
-
-    # Current event structure:
-    # grouped_events = {year: {month: {day: [<Event 1>, <Event 2>]}}}
-
-    # Combine both dictionaries to determine timeline structure
-    final_group = copy.deepcopy(grouped_events)
-
-    for year, month in combined_epochs.items():
-        if year in final_group:
-            for month in combined_epochs[year]:
-                if month not in final_group[year]:
-                    final_group[year][month] = combined_epochs[year][month]  
-        else:
-            final_group[year] = combined_epochs[year]
-
-    # Sort final grouping into year order
-    final_group = {key: value for key, value in sorted(final_group.items())}
-    # Sort final grouping months
-    for year in final_group:
-        for month in final_group[year]:
-            final_group[year] = {key: value for key, value in sorted(final_group[year].items())}
+    final_group = merge_dicts(year_dict, combined_epochs_dict)
 
     # Turn each level of the hierarchy into an object, with the level below as a list held in a property
     year_list = []
@@ -225,11 +219,6 @@ def campaign_sort(campaign):
 
         year_object = Year()
         year_object.name = str(year)
-        try:
-            year_object.marker = check_year_marker(grouped_events[year])
-        # Catch exception if year only has epoch and nothing else
-        except KeyError:
-            year_object.marker = False
 
         for month_index, month in enumerate(final_group[year]):
 
@@ -238,7 +227,7 @@ def campaign_sort(campaign):
 
             # Determine if the following month is the next consecutive month
             if has_following(index=month_index, level=final_group[year], current_item=month):
-                    month_object.has_following_month = True
+                month_object.has_following_month = True
 
             for day_index, day in enumerate(final_group[year][month]):
 
@@ -249,34 +238,26 @@ def campaign_sort(campaign):
                 if has_following(index=day_index, level=final_group[year][month], current_item=day):
                     day_object.has_following_day = True
 
-                try:
-                    for event in grouped_events[year][month][day]:
-                        # Append the event to the day object
-                        day_object.events.append(event)
-                # Catch exception if month has no days (IE, only has epochs)
-                except KeyError:
-                    continue
+                # Append all the days event to the day object
+                for event in final_group[year][month][day]:
+                    day_object.events.append(event)
+
+                # Check if day has any epoch starts
+                check_for_epoch(epoch_start_dict, 
+                                year, month, day,
+                                day_object, 
+                                "has_epoch", 
+                                day_object.epochs)
+                
+                # Check if day has any epoch ends
+                check_for_epoch(epoch_end_dict, 
+                                year, month, day,
+                                day_object, 
+                                "has_epoch_end", 
+                                day_object.end_epochs)
 
                 # Append the day object to the month object
                 month_object.days.append(day_object)
-
-            # Check if any epoch starts occur in month
-            if year in epochs_by_start_date:
-                if month in epochs_by_start_date[year]:
-                    month_object.has_epoch = True
-                    month_object.epochs = epochs_by_start_date[year][month]
-                    for epoch in month_object.epochs:
-                        if len(epoch.events) > 0:
-                            month_object.epoch_has_events = True
-
-            # Check if any epoch ends occur in month
-            if year in epochs_by_end_date:
-                if month in epochs_by_end_date[year]:
-                    month_object.has_epoch_end = True
-                    month_object.end_epochs = epochs_by_end_date[year][month]
-                    for epoch in month_object.end_epochs:
-                        if len(epoch.events) > 0:
-                            month_object.epoch_has_events = True
 
             # Append the month object to the year object
             year_object.months.append(month_object)   

--- a/app/utils/organisers.py
+++ b/app/utils/organisers.py
@@ -1,6 +1,4 @@
-from itertools import groupby
 import copy
-from collections import defaultdict
 
 from app import db, models
 

--- a/app/utils/organisers.py
+++ b/app/utils/organisers.py
@@ -82,6 +82,8 @@ def campaign_sort(campaign):
             else:
                 combined_dict[year] = dict2[year]
 
+        combined_dict = {key: value for key, value in sorted(combined_dict.items())}
+
         return combined_dict
 
 
@@ -121,7 +123,7 @@ def campaign_sort(campaign):
             return False
 
 
-    def check_for_epoch(dictionary, year, month, day, month_object, day_object, has_epoch_attr, epochs_attr):
+    def check_for_epoch(dictionary, year, month, day, day_object, has_epoch_attr, epochs_attr):
         try:
             epochs = dictionary[year][month][day]
         except KeyError:
@@ -204,12 +206,12 @@ def campaign_sort(campaign):
 
                 # Append all the days event to the day object
                 for event in final_group[year][month][day]:
-                    day_object.events.append(event)
+                    if isinstance(event, models.Event):
+                        day_object.events.append(event)
 
                 # Check if day has any epoch starts
                 check_for_epoch(epoch_start_dict, 
                                 year, month, day,
-                                month_object,
                                 day_object, 
                                 "has_epoch", 
                                 day_object.epochs)
@@ -217,7 +219,6 @@ def campaign_sort(campaign):
                 # Check if day has any epoch ends
                 check_for_epoch(epoch_end_dict, 
                                 year, month, day,
-                                month_object,
                                 day_object, 
                                 "has_epoch_end", 
                                 day_object.end_epochs)

--- a/app/utils/serialisers.py
+++ b/app/utils/serialisers.py
@@ -208,6 +208,10 @@ def epochs_import(epoch):
     except AttributeError:
         errors.append("Incorrect date format")
     try:
+        new_epoch.start_day = new_epoch.split_date(new_epoch.start_date)[2]
+    except ValueError:
+        errors.append("Incorrect date format")
+    try:
         new_epoch.end_date = epoch["end_date"]
     except KeyError:
         errors.append("Unable to locate epoch end date")
@@ -219,6 +223,10 @@ def epochs_import(epoch):
         errors.append("Incorrect date format")
     try:
         new_epoch.end_month = new_epoch.split_date(new_epoch.end_date)[1]
+    except ValueError:
+        errors.append("Incorrect date format")
+    try:
+        new_epoch.end_day = new_epoch.split_date(new_epoch.end_date)[2]
     except ValueError:
         errors.append("Incorrect date format")
     try:


### PR DESCRIPTION
Moves epochs to the day level in the timeline

Gives epoch models a start_day and end_day property, and refactors the campaign_sort function to place epochs at day level in the year_list structure used for timeline template rendering.
Updates timeline templates and adds small js solution to render epochs at day level properly.
Updates epoch forms and backup routes to accomodate these new properties.
Adds basic epoch route tests.