### PR TITLE
Replace Deprecated Bleach Module with nh3

### DIFF
--- a/app/tests/test_utils/test_sanitisers.py
+++ b/app/tests/test_utils/test_sanitisers.py
@@ -8,19 +8,21 @@ def test_sanitise_input():
     assert sanitise_input(value, allow_images=True) == expected_output
 
     value = '<img src="image.jpg"/>'
-    expected_output = '<p>&lt;img src="image.jpg"/&gt;</p>'
+    expected_output = ''
     assert sanitise_input(value, allow_images=False) == expected_output
 
-    value = '<p style="disallowed style tag">Text with disallowed style</p>'
-    expected_output = '<p style="">Text with disallowed style</p>'
-    print(sanitise_input(value))
-    assert sanitise_input(value) == expected_output
-
     value = '<script>Text with disallowed tag</script>'
-    expected_output = '<p>&lt;script&gt;Text with disallowed tag&lt;/script&gt;</p>'
-    print(sanitise_input(value))
+    expected_output = ''
     assert sanitise_input(value) == expected_output
 
     value = "Text without tags"
     expected_output = "<p>Text without tags</p>"
     assert sanitise_input(value) == expected_output
+
+    value = "Message body that shouldn't have p tags"
+    expected_output = "Message body that shouldn't have p tags"
+    assert sanitise_input(value, message_body=True) == expected_output
+
+    value = '<a href="http://www.google.com">LINK TEXT</a>'
+    expected_output = '<a href="http://www.google.com" rel="noopener noreferrer nofollow">LINK TEXT</a>'
+    assert sanitise_input(value, message_body=True) == expected_output

--- a/app/utils/sanitisers.py
+++ b/app/utils/sanitisers.py
@@ -1,38 +1,34 @@
-import bleach
-from bleach.css_sanitizer import CSSSanitizer
+import nh3
 from bs4 import BeautifulSoup
 
 
 def sanitise_input(value, allow_images=True, message_body=False):
-    """ Method to sanitise user submitted html input. Uses Bleach
-        and CSSSanitizer. """
+    """ Method to sanitise user submitted html input using nh3. """
 
-    allowed_tags = ["p", "b", "i", "em", "h1", "h2", "h3", "a", "br", "u", "img", "li", "ul", "ol", "strong"]
+    allowed_tags = {"p", "b", "i", "em", "h1", "h2", "h3", "a", "br", "u", "img", "li", "ul", "ol", "strong"}
     if not allow_images:
         allowed_tags.remove("img")
-        
-    allowed_attrs = {
-        "*": ["class"],
-        "a": ["href", "rel"],
-        "img": ["alt", "src", "style"],
-        "p": ["align", "style"],
-    }
-    allowed_styles = ["height", "width", "margin-left"]
 
-    value = bleach.clean(value,
-                         tags=allowed_tags,
-                         attributes=allowed_attrs,
-                         css_sanitizer=CSSSanitizer(allowed_css_properties=allowed_styles))
+    allowed_attrs = {
+        "*": {"class"},
+        "a": {"href", "title", "target"},
+        "img": {"alt", "src", "style"},
+        "p": {"align", "style"},
+    }
+
+    cleaned_input = nh3.clean(value,
+                              tags=allowed_tags,
+                              attributes=allowed_attrs,
+                              link_rel="noopener noreferrer nofollow")
 
     # Wrap any text without tags in <p> tags
     # Not applicable for message body text
     if not message_body:
-        soup = BeautifulSoup(value, "html.parser")
+        soup = BeautifulSoup(cleaned_input, "html.parser")
         for text in soup.find_all(string=True):
             if text.parent.name not in allowed_tags:
                 new_tag = soup.new_tag("p")
                 text.wrap(new_tag)
         return str(soup)
     else:
-        return value
-    
+        return cleaned_input

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 alembic==1.11.1
 APScheduler~=3.10.4
 beautifulsoup4==4.11.2
-bleach==6.1.0
-bleach[css]==6.1.0
 python-dotenv==0.18.0
 editdistance==0.6.2
 email-validator==1.3.1
@@ -16,6 +14,7 @@ Flask_WTF==1.2.1
 gunicorn==21.2.0
 lemminflect==0.2.3
 mailersend==0.5.6
+nh3==0.2.17
 nltk==3.8.1
 psycopg2==2.9.9
 PyJWT==2.8.0


### PR DESCRIPTION
Drops depracted Bleach module usage, replacing with nh3 for html sanitisation. Results in both faster and more secure user HTML validation. Updates all tests accordingly. Also includes more robust user submitted link sanitisation.