### PR TITLE
Add Flask-Caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ WAR/COR is a dynamic timeline creator app, for structured, military-style RPG co
 ### Extensions
 
 - Flask-APScheduler
+- Flask-Caching
 - Flask-Limiter
 - Flask-Login
 - Flask-Migrate

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 from flask import Flask
 from flask_apscheduler import APScheduler
+from flask_caching import Cache
 from flask_sqlalchemy import SQLAlchemy
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
@@ -13,11 +14,13 @@ from logging.handlers import SMTPHandler
 
 from app.utils.generators import create_data
 
-db = SQLAlchemy()
+
+cache = Cache()
 csrf = CSRFProtect()
-scheduler = APScheduler()
+db = SQLAlchemy()
 limiter = Limiter(get_remote_address,
                   default_limits=["2/second", "30/minute"])
+scheduler = APScheduler()
 
 
 # Application factory
@@ -38,7 +41,10 @@ def create_app(config_class=Config):
 
         # Initialise db migrations
         migrate = Migrate(flask_app, db)
-        
+
+        # Initiliase cache
+        cache.init_app(flask_app)
+
         # Initialise Flask Limiter
         if not flask_app.config["TESTING"] and not flask_app.config["DEBUG"]:
             limiter.init_app(flask_app)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -32,24 +32,22 @@ def create_app(config_class=Config):
 
     with flask_app.app_context():
 
-        # Initialise database and import models
+        # Initialise database
         db.init_app(flask_app)
         import app.models
-
-        # Create the database
         db.create_all()
 
         # Initialise db migrations
         migrate = Migrate(flask_app, db)
 
-        # Initiliase cache
+        # Initialise Flask-Caching
         cache.init_app(flask_app)
 
-        # Initialise Flask Limiter
+        # Initialise Flask-Limiter
         if not flask_app.config["TESTING"] and not flask_app.config["DEBUG"]:
             limiter.init_app(flask_app)
 
-        # Initialise APScheduler
+        # Initialise Flask-APScheduler
         if not flask_app.config["DEBUG"]:
             scheduler.init_app(flask_app)
             import app.utils.tasks
@@ -117,7 +115,7 @@ def create_app(config_class=Config):
     flask_app.register_blueprint(test_bp)
 
     # Disable browser caching during debug
-    if flask_app.config["DEBUG"]:
+    if flask_app.debug:
         @flask_app.after_request
         def after_request(response):
             response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate, public, max-age=0"
@@ -152,7 +150,7 @@ def create_app(config_class=Config):
         create_data()
 
     # Configure email error logging via SMTP
-    if not flask_app.debug:
+    if not flask_app.debug and not flask_app.testing:
 
         if flask_app.config["MAIL_SERVER"]:
             auth = None
@@ -162,7 +160,7 @@ def create_app(config_class=Config):
 
             secure = None
 
-            if flask_app.config['MAIL_USE_TLS']:
+            if flask_app.config["MAIL_USE_TLS"]:
                 secure = ()
                 
             mail_handler = SMTPHandler(

--- a/app/models/campaign.py
+++ b/app/models/campaign.py
@@ -66,12 +66,20 @@ class Campaign(db.Model):
                 setattr(self, field, value)
 
         self.last_edited = datetime.now()
+        self.clear_cache()
         self.set_url_title()
 
         if new:
             db.session.add(self)
 
         db.session.commit()
+
+    def clear_cache(self):
+        """ Method to update last_edited value, and clear any out of date
+            cached data. Set commit to True if needing to call db.session.commit,
+            IE - from """
+    
+        cache.delete_memoized(self.return_timeline_data)
 
     def remove_user(self, user):
         """ Method to remove a given user from campaign """
@@ -126,10 +134,8 @@ class Campaign(db.Model):
         
         self.url_title = self.title.replace(" ", "-")
 
-    @cache.memoize()
+    @cache.memoize(900)
     def return_timeline_data(self, epoch=None):
         """ Method to return campaign timeline data """
+        
         return organisers.campaign_sort(self, epoch)
-
-    def __repr__(self):
-        return "%s(%s, %s)" % (self.__class__.__name__, self.id, self.last_edited)

--- a/app/models/campaign.py
+++ b/app/models/campaign.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from app import db
+from app import db, cache
 from app.utils.sanitisers import sanitise_input
 import app.utils.organisers as organisers
 
@@ -126,6 +126,10 @@ class Campaign(db.Model):
         
         self.url_title = self.title.replace(" ", "-")
 
+    @cache.memoize()
     def return_timeline_data(self, epoch=None):
         """ Method to return campaign timeline data """
         return organisers.campaign_sort(self, epoch)
+
+    def __repr__(self):
+        return "%s(%s, %s)" % (self.__class__.__name__, self.id, self.last_edited)

--- a/app/models/campaign.py
+++ b/app/models/campaign.py
@@ -75,9 +75,7 @@ class Campaign(db.Model):
         db.session.commit()
 
     def clear_cache(self):
-        """ Method to update last_edited value, and clear any out of date
-            cached data. Set commit to True if needing to call db.session.commit,
-            IE - from """
+        """ Method to clear any out of date cached data. """
     
         cache.delete_memoized(self.return_timeline_data)
 

--- a/app/models/epoch.py
+++ b/app/models/epoch.py
@@ -88,6 +88,7 @@ class Epoch(db.Model):
 
         self.parent_campaign = parent_campaign
         self.parent_campaign.last_edited = datetime.now()
+        self.parent_campaign.clear_cache()
         self.set_url_title()
         
         if new:

--- a/app/models/event.py
+++ b/app/models/event.py
@@ -79,6 +79,7 @@ class Event(db.Model):
 
         self.parent_campaign = parent_campaign
         self.parent_campaign.last_edited = datetime.now()
+        self.parent_campaign.clear_cache()
         self.set_url_title()
         
         if new:

--- a/app/routes/event/routes.py
+++ b/app/routes/event/routes.py
@@ -206,6 +206,7 @@ def delete_event(campaign_name, campaign_id, event_name, event_id):
     authenticators.permission_required(campaign)
 
     campaign.last_edited = datetime.now()
+    campaign.clear_cache()
 
     db.session.delete(event)
     db.session.commit()

--- a/app/tests/fixtures/event.py
+++ b/app/tests/fixtures/event.py
@@ -8,7 +8,7 @@ class EventActions(object):
     def __init__(self, client):
         self._client = client
 
-    def create(self, campaign_object, data):
+    def create(self, campaign_object, data, no_redirect=False):
 
         url = url_for("event.add_event",
                       campaign_name=campaign_object.title,
@@ -19,7 +19,10 @@ class EventActions(object):
             if field.name not in data:
                 data[field.name] = ""
 
-        return self._client.post(url, data=data, follow_redirects=True)
+        if no_redirect:
+            return self._client.post(url, data=data, follow_redirects=False)
+        else:
+            return self._client.post(url, data=data, follow_redirects=True)
 
     def edit(self, campaign_object, event_object, data):
 
@@ -53,14 +56,16 @@ class EventActions(object):
                 new_event = EventFormat(starting_date=starting_date)
                 all_events.append(new_event)
                 self.create(campaign_object=campaign_object,
-                            data=new_event.return_new_event_data())
+                            data=new_event.return_new_event_data(),
+                            no_redirect=True)
             else:
                 new_event = EventFormat(previous_event=all_events[index - 1],
                                         starting_date=starting_date,
                                         increment=increment)
                 all_events.append(new_event)
                 self.create(campaign_object=campaign_object,
-                            data=new_event.return_new_event_data())
+                            data=new_event.return_new_event_data(),
+                            no_redirect=True)
 
 
 class EventFormat:

--- a/app/tests/test_models/test_model_campaign.py
+++ b/app/tests/test_models/test_model_campaign.py
@@ -170,5 +170,3 @@ def test_return_timeline_data(client, auth, campaign, event, epoch):
                         assert day.has_epoch_end
                     else:
                         assert not day.has_epoch_end
-
-

--- a/config.py
+++ b/config.py
@@ -38,6 +38,8 @@ class Config(object):
     SCHEDULER_TIMEZONE = "UTC"
     # Flask-APScheduler
     SCHEDULER_API_ENABLED = False
+    # Flask-Caching
+    CACHE_TYPE = "SimpleCache"
 
 
 class TestingConfig(Config):
@@ -71,3 +73,7 @@ class ProductionConfig(Config):
     RATELIMIT_STORAGE_URI = os.environ.get("REDIS_STORAGE_URI")
     RATELIMIT_STORAGE_OPTIONS = {"socket_connect_timeout": 30}
     RATELIMIT_STRATEGY = "fixed-window"
+    # Flask-Caching
+    CACHE_TYPE = "RedisCache"
+    CACHE_REDIS_URL = os.environ.get("REDIS_STORAGE_URI")
+    

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ editdistance==0.6.2
 email-validator==1.3.1
 Flask==3.0.2
 Flask-APScheduler==1.13.1
+Flask-Caching==2.2.0
 Flask-Limiter[redis]==3.6.0
 Flask_Login==0.6.3
 Flask_Migrate==4.0.5


### PR DESCRIPTION
Adds Flask-Caching to app and memoizes the campaign.return_timeline_data() method. Memoized data is invalidated upon any updates to the campaign, and is cleared after 15 minutes.
When using the development server, Flask-Caching is configured to use an in memory SimpleCache, whilst the production config is configured for a Redis instance backend.